### PR TITLE
AmpTask1524_Use_joblib_helpers_for_run_experiment

### DIFF
--- a/core/config/config_.py
+++ b/core/config/config_.py
@@ -339,7 +339,8 @@ class Config:
             % (key, self._config[key], pri.indent(str(self)))
         )
 
-    def _parse_compound_key(self, key: Key) -> Tuple[str, Iterable[str]]:
+    @staticmethod
+    def _parse_compound_key(key: Key) -> Tuple[str, Iterable[str]]:
         dbg.dassert(intr.is_iterable(key), "Key='%s' is not iterable", key)
         head_key, tail_key = key[0], key[1:]  # type: ignore
         _LOG.debug(

--- a/core/dataflow_model/test/simple_experiment.py
+++ b/core/dataflow_model/test/simple_experiment.py
@@ -7,7 +7,7 @@ _LOG = logging.getLogger(__name__)
 
 def run_experiment(config: cconfig.Config) -> None:
     """
-    This experiment fails/succeeds depending on the return code stored inside
+    This experiment fails/succeeds depending on the param `fail` stored inside
     the config.
     """
     _LOG.info("config=\n%s", config)

--- a/core/dataflow_model/test/test_run_experiment.py
+++ b/core/dataflow_model/test/test_run_experiment.py
@@ -1,133 +1,183 @@
 import logging
 import os
-from typing import List
+from typing import Any, List
 
 import pytest
 
+import dev_scripts.test.test_run_notebook as trnot
 import helpers.dbg as dbg
 import helpers.git as git
-import helpers.system_interaction as si
 import helpers.unit_test as hut
 
 _LOG = logging.getLogger(__name__)
 
 
+# TODO(gp): We could factor out more common code between here and the corresponding
+#  unit tests in TestRuNotebook*. The difference is only in the command lines.
 class TestRunExperiment1(hut.TestCase):
     """
+    Run experiments without failures.
+
     These tests are equivalent to `TestRunNotebook1` but using the
     `run_experiment.py` flow instead of `run_notebook.py`.
     """
 
-    def test1(self) -> None:
+    EXPECTED_OUTCOME = r"""# Dir structure
+        $SCRATCH_SPACE
+        $SCRATCH_SPACE/result_0
+        $SCRATCH_SPACE/result_0/config.pkl
+        $SCRATCH_SPACE/result_0/config.txt
+        $SCRATCH_SPACE/result_0/run_experiment.0.log
+        $SCRATCH_SPACE/result_0/success.txt
+        $SCRATCH_SPACE/result_1
+        $SCRATCH_SPACE/result_1/config.pkl
+        $SCRATCH_SPACE/result_1/config.txt
+        $SCRATCH_SPACE/result_1/run_experiment.1.log
+        $SCRATCH_SPACE/result_1/success.txt"""
+
+    def test_serial1(self) -> None:
         """
-        Run two experiments (without any failure) serially.
+        Execute:
+        - two experiments (without any failure)
+        - serially
         """
-        cmd = [
+        cmd_opts = [
             "--config_builder 'dev_scripts.test.test_run_notebook.build_configs1()'",
             "--num_threads 'serial'",
         ]
-        # pylint: enable=line-too-long
-        exp = r"""# Dir structure
-$GIT_ROOT/core/dataflow_model/test/TestRunExperiment1.test1/tmp.scratch
-$GIT_ROOT/core/dataflow_model/test/TestRunExperiment1.test1/tmp.scratch/result_0
-$GIT_ROOT/core/dataflow_model/test/TestRunExperiment1.test1/tmp.scratch/result_0/config.pkl
-$GIT_ROOT/core/dataflow_model/test/TestRunExperiment1.test1/tmp.scratch/result_0/config.txt
-$GIT_ROOT/core/dataflow_model/test/TestRunExperiment1.test1/tmp.scratch/result_0/run_experiment.0.log
-$GIT_ROOT/core/dataflow_model/test/TestRunExperiment1.test1/tmp.scratch/result_0/success.txt
-$GIT_ROOT/core/dataflow_model/test/TestRunExperiment1.test1/tmp.scratch/result_1
-$GIT_ROOT/core/dataflow_model/test/TestRunExperiment1.test1/tmp.scratch/result_1/config.pkl
-$GIT_ROOT/core/dataflow_model/test/TestRunExperiment1.test1/tmp.scratch/result_1/config.txt
-$GIT_ROOT/core/dataflow_model/test/TestRunExperiment1.test1/tmp.scratch/result_1/run_experiment.1.log
-$GIT_ROOT/core/dataflow_model/test/TestRunExperiment1.test1/tmp.scratch/result_1/success.txt"""
-        # pylint: disable=line-too-long
+        #
         exp_pass = True
-        self._run_experiment_helper(cmd, exp_pass, exp)
+        _run_experiment_helper(self, cmd_opts, exp_pass, self.EXPECTED_OUTCOME)
 
     @pytest.mark.slow
-    def test2(self) -> None:
+    def test_parallel1(self) -> None:
         """
-        Run two experiments (without any failure) with 2 threads.
+        Execute:
+        - two experiments (without any failure)
+        - with 2 threads
         """
-        cmd = [
+        cmd_opts = [
             "--config_builder 'dev_scripts.test.test_run_notebook.build_configs1()'",
             "--num_threads 2",
         ]
-        # pylint: enable=line-too-long
-        exp = r"""# Dir structure
-$GIT_ROOT/core/dataflow_model/test/TestRunExperiment1.test2/tmp.scratch
-$GIT_ROOT/core/dataflow_model/test/TestRunExperiment1.test2/tmp.scratch/result_0
-$GIT_ROOT/core/dataflow_model/test/TestRunExperiment1.test2/tmp.scratch/result_0/config.pkl
-$GIT_ROOT/core/dataflow_model/test/TestRunExperiment1.test2/tmp.scratch/result_0/config.txt
-$GIT_ROOT/core/dataflow_model/test/TestRunExperiment1.test2/tmp.scratch/result_0/run_experiment.0.log
-$GIT_ROOT/core/dataflow_model/test/TestRunExperiment1.test2/tmp.scratch/result_0/success.txt
-$GIT_ROOT/core/dataflow_model/test/TestRunExperiment1.test2/tmp.scratch/result_1
-$GIT_ROOT/core/dataflow_model/test/TestRunExperiment1.test2/tmp.scratch/result_1/config.pkl
-$GIT_ROOT/core/dataflow_model/test/TestRunExperiment1.test2/tmp.scratch/result_1/config.txt
-$GIT_ROOT/core/dataflow_model/test/TestRunExperiment1.test2/tmp.scratch/result_1/run_experiment.1.log
-$GIT_ROOT/core/dataflow_model/test/TestRunExperiment1.test2/tmp.scratch/result_1/success.txt"""
-        # pylint: disable=line-too-long
+        #
         exp_pass = True
-        self._run_experiment_helper(cmd, exp_pass, exp)
+        _run_experiment_helper(self, cmd_opts, exp_pass, self.EXPECTED_OUTCOME)
+
+
+# #############################################################################
+
+
+class TestRunExperiment2(hut.TestCase):
+    """
+    Run experiments that fail.
+    """
+
+    EXPECTED_OUTCOME = r"""# Dir structure
+        $SCRATCH_SPACE
+        $SCRATCH_SPACE/result_0
+        $SCRATCH_SPACE/result_0/config.pkl
+        $SCRATCH_SPACE/result_0/config.txt
+        $SCRATCH_SPACE/result_0/run_experiment.0.log
+        $SCRATCH_SPACE/result_0/success.txt
+        $SCRATCH_SPACE/result_1
+        $SCRATCH_SPACE/result_1/config.pkl
+        $SCRATCH_SPACE/result_1/config.txt
+        $SCRATCH_SPACE/result_1/run_experiment.1.log
+        $SCRATCH_SPACE/result_1/success.txt
+        $SCRATCH_SPACE/result_2
+        $SCRATCH_SPACE/result_2/config.pkl
+        $SCRATCH_SPACE/result_2/config.txt
+        $SCRATCH_SPACE/result_2/run_experiment.2.log"""
 
     @pytest.mark.slow
-    def test3(self) -> None:
+    def test_serial1(self) -> None:
         """
-        Run an experiment with 3 notebooks (with one failing) using 3 threads.
+        Execute:
+        - 3 experiments with one failing
+        - serially
+        - aborting on error
         """
-        cmd = [
+        cmd_opts = [
+            "--config_builder 'dev_scripts.test.test_run_notebook.build_configs2()'",
+            "--num_threads serial",
+        ]
+        #
+        exp_pass = False
+        _LOG.warning("This command is supposed to fail")
+        _run_experiment_helper(self, cmd_opts, exp_pass, self.EXPECTED_OUTCOME)
+
+    @pytest.mark.slow
+    def test_serial2(self) -> None:
+        """
+        Execute:
+        - 3 experiments with one failing
+        - serially
+        - skipping on error
+        """
+        cmd_opts = [
             "--config_builder 'dev_scripts.test.test_run_notebook.build_configs2()'",
             "--skip_on_error",
-            "--num_threads 3",
+            "--num_threads serial",
         ]
-        _LOG.warning("This command is supposed to fail")
-        # pylint: enable=line-too-long
-        exp = r"""# Dir structure
-$GIT_ROOT/core/dataflow_model/test/TestRunExperiment1.test3/tmp.scratch
-$GIT_ROOT/core/dataflow_model/test/TestRunExperiment1.test3/tmp.scratch/result_0
-$GIT_ROOT/core/dataflow_model/test/TestRunExperiment1.test3/tmp.scratch/result_0/config.pkl
-$GIT_ROOT/core/dataflow_model/test/TestRunExperiment1.test3/tmp.scratch/result_0/config.txt
-$GIT_ROOT/core/dataflow_model/test/TestRunExperiment1.test3/tmp.scratch/result_0/run_experiment.0.log
-$GIT_ROOT/core/dataflow_model/test/TestRunExperiment1.test3/tmp.scratch/result_0/success.txt
-$GIT_ROOT/core/dataflow_model/test/TestRunExperiment1.test3/tmp.scratch/result_1
-$GIT_ROOT/core/dataflow_model/test/TestRunExperiment1.test3/tmp.scratch/result_1/config.pkl
-$GIT_ROOT/core/dataflow_model/test/TestRunExperiment1.test3/tmp.scratch/result_1/config.txt
-$GIT_ROOT/core/dataflow_model/test/TestRunExperiment1.test3/tmp.scratch/result_1/run_experiment.1.log
-$GIT_ROOT/core/dataflow_model/test/TestRunExperiment1.test3/tmp.scratch/result_1/success.txt
-$GIT_ROOT/core/dataflow_model/test/TestRunExperiment1.test3/tmp.scratch/result_2
-$GIT_ROOT/core/dataflow_model/test/TestRunExperiment1.test3/tmp.scratch/result_2/config.pkl
-$GIT_ROOT/core/dataflow_model/test/TestRunExperiment1.test3/tmp.scratch/result_2/config.txt
-$GIT_ROOT/core/dataflow_model/test/TestRunExperiment1.test3/tmp.scratch/result_2/run_experiment.2.log"""
-        # pylint: disable=line-too-long
-        exp_pass = False
-        self._run_experiment_helper(cmd, exp_pass, exp)
+        #
+        exp_pass = True
+        _run_experiment_helper(self, cmd_opts, exp_pass, self.EXPECTED_OUTCOME)
 
-    def _run_experiment_helper(self, cmd: List[str], exp_pass: bool, exp: str) -> None:
-        amp_path = git.get_amp_abs_path()
-        # Get the executable.
-        exec_file = os.path.join(
-            amp_path, "core/dataflow_model/run_experiment.py"
-        )
-        dbg.dassert_file_exists(exec_file)
-        # Build command line.
-        dst_dir = self.get_scratch_space()
-        cmd_tmp = [
-            f"{exec_file}",
-            "--experiment_builder core.dataflow_model.test.simple_experiment.run_experiment",
-            f"--dst_dir {dst_dir}",
+    @pytest.mark.slow
+    def test_parallel1(self) -> None:
+        """
+        Execute:
+        - 3 experiments with one failing
+        - with 2 threads
+        - aborting on error
+
+        Same as `test_serial1` but using 2 threads.
+        """
+        cmd_opts = [
+            "--config_builder 'dev_scripts.test.test_run_notebook.build_configs2()'",
+            "--num_threads 2",
         ]
-        cmd_tmp.extend(cmd)
-        cmd = " ".join(cmd_tmp)
-        # Run command.
-        abort_on_error = exp_pass
-        _LOG.debug("exp_pass=%s abort_on_error=%s", exp_pass, abort_on_error)
-        rc = si.system(cmd, abort_on_error=abort_on_error, suppress_output=False)
-        if exp_pass:
-            self.assertEqual(rc, 0)
-        else:
-            self.assertNotEqual(rc, 0)
-        # Compute and compare the dir signature.
-        act = hut.get_dir_signature(
-            dst_dir, include_file_content=False, num_lines=None
-        )
-        act = hut.purify_txt_from_client(act)
-        self.assert_equal(act, exp, fuzzy_match=True)
+        #
+        exp_pass = False
+        _LOG.warning("This command is supposed to fail")
+        _run_experiment_helper(self, cmd_opts, exp_pass, self.EXPECTED_OUTCOME)
+
+    @pytest.mark.slow
+    def test_parallel2(self) -> None:
+        """
+        Execute:
+        - 3 experiments with one failing
+        - with 2 threads
+        - skipping on error
+
+        Same as `test_serial1` but using 2 threads.
+        """
+        cmd_opts = [
+            "--config_builder 'dev_scripts.test.test_run_notebook.build_configs2()'",
+            "--skip_on_error",
+            "--num_threads 2",
+        ]
+        #
+        exp_pass = True
+        _run_experiment_helper(self, cmd_opts, exp_pass, self.EXPECTED_OUTCOME)
+
+
+# #############################################################################
+
+
+def _run_experiment_helper(
+    self: Any, cmd_opts: List[str], exp_pass: bool, exp: str
+) -> None:
+    amp_path = git.get_amp_abs_path()
+    # Get the executable.
+    exec_file = os.path.join(amp_path, "core/dataflow_model/run_experiment.py")
+    dbg.dassert_file_exists(exec_file)
+    # Build command line.
+    dst_dir = self.get_scratch_space()
+    cmd = [
+        f"{exec_file}",
+        "--experiment_builder core.dataflow_model.test.simple_experiment.run_experiment",
+        f"--dst_dir {dst_dir}",
+    ]
+    trnot.run_cmd_line(self, cmd, cmd_opts, dst_dir, exp, exp_pass)

--- a/dev_scripts/test/test_run_notebook.py
+++ b/dev_scripts/test/test_run_notebook.py
@@ -1,12 +1,13 @@
 import logging
 import os
-from typing import List, Tuple
+from typing import Any, List, Tuple, cast
 
 import pytest
 
 import core.config as cconfig
 import helpers.dbg as dbg
 import helpers.git as git
+import helpers.printing as hprint
 import helpers.system_interaction as si
 import helpers.unit_test as hut
 
@@ -14,146 +15,194 @@ _LOG = logging.getLogger(__name__)
 
 
 class TestRunNotebook1(hut.TestCase):
-    def test1(self) -> None:
+    """
+    Run notebooks without failures.
+    """
+
+    EXPECTED_OUTCOME = r"""# Dir structure
+        $SCRATCH_SPACE
+        $SCRATCH_SPACE/result_0
+        $SCRATCH_SPACE/result_0/config.pkl
+        $SCRATCH_SPACE/result_0/config.txt
+        $SCRATCH_SPACE/result_0/run_notebook.0.log
+        $SCRATCH_SPACE/result_0/simple_notebook.0.ipynb
+        $SCRATCH_SPACE/result_0/success.txt
+        $SCRATCH_SPACE/result_1
+        $SCRATCH_SPACE/result_1/config.pkl
+        $SCRATCH_SPACE/result_1/config.txt
+        $SCRATCH_SPACE/result_1/run_notebook.1.log
+        $SCRATCH_SPACE/result_1/simple_notebook.1.ipynb
+        $SCRATCH_SPACE/result_1/success.txt"""
+
+    def test_serial1(self) -> None:
         """
-        Run an experiment with 2 notebooks (without any failure) serially.
+        Execute:
+        - two notebooks (without any failure)
+        - serially
         """
-        cmd = [
+        cmd_opts = [
             "--config_builder 'dev_scripts.test.test_run_notebook.build_configs1()'",
             "--num_threads 'serial'",
         ]
-        # pylint: enable=line-too-long
-        exp = r"""# Dir structure
-$GIT_ROOT/dev_scripts/test/TestRunNotebook1.test1/tmp.scratch
-$GIT_ROOT/dev_scripts/test/TestRunNotebook1.test1/tmp.scratch/result_0
-$GIT_ROOT/dev_scripts/test/TestRunNotebook1.test1/tmp.scratch/result_0/config.pkl
-$GIT_ROOT/dev_scripts/test/TestRunNotebook1.test1/tmp.scratch/result_0/config.txt
-$GIT_ROOT/dev_scripts/test/TestRunNotebook1.test1/tmp.scratch/result_0/run_notebook.0.log
-$GIT_ROOT/dev_scripts/test/TestRunNotebook1.test1/tmp.scratch/result_0/simple_notebook.0.ipynb
-$GIT_ROOT/dev_scripts/test/TestRunNotebook1.test1/tmp.scratch/result_0/success.txt
-$GIT_ROOT/dev_scripts/test/TestRunNotebook1.test1/tmp.scratch/result_1
-$GIT_ROOT/dev_scripts/test/TestRunNotebook1.test1/tmp.scratch/result_1/config.pkl
-$GIT_ROOT/dev_scripts/test/TestRunNotebook1.test1/tmp.scratch/result_1/config.txt
-$GIT_ROOT/dev_scripts/test/TestRunNotebook1.test1/tmp.scratch/result_1/run_notebook.1.log
-$GIT_ROOT/dev_scripts/test/TestRunNotebook1.test1/tmp.scratch/result_1/simple_notebook.1.ipynb
-$GIT_ROOT/dev_scripts/test/TestRunNotebook1.test1/tmp.scratch/result_1/success.txt"""
-        # pylint: disable=line-too-long
+        #
         exp_pass = True
-        self._run_notebook_helper(cmd, exp_pass, exp)
+        _run_notebook_helper(self, cmd_opts, exp_pass, self.EXPECTED_OUTCOME)
 
     @pytest.mark.slow
-    def test2(self) -> None:
+    def test_parallel1(self) -> None:
         """
-        Run an experiment with 2 notebooks (without any failure) with 2
-        threads.
+        Execute:
+        - two experiments (without any failure)
+        - with 2 threads
         """
-        cmd = [
+        cmd_opts = [
             "--config_builder 'dev_scripts.test.test_run_notebook.build_configs1()'",
             "--num_threads 2",
         ]
-        # pylint: enable=line-too-long
-        exp = r"""# Dir structure
-$GIT_ROOT/dev_scripts/test/TestRunNotebook1.test2/tmp.scratch
-$GIT_ROOT/dev_scripts/test/TestRunNotebook1.test2/tmp.scratch/result_0
-$GIT_ROOT/dev_scripts/test/TestRunNotebook1.test2/tmp.scratch/result_0/config.pkl
-$GIT_ROOT/dev_scripts/test/TestRunNotebook1.test2/tmp.scratch/result_0/config.txt
-$GIT_ROOT/dev_scripts/test/TestRunNotebook1.test2/tmp.scratch/result_0/run_notebook.0.log
-$GIT_ROOT/dev_scripts/test/TestRunNotebook1.test2/tmp.scratch/result_0/simple_notebook.0.ipynb
-$GIT_ROOT/dev_scripts/test/TestRunNotebook1.test2/tmp.scratch/result_0/success.txt
-$GIT_ROOT/dev_scripts/test/TestRunNotebook1.test2/tmp.scratch/result_1
-$GIT_ROOT/dev_scripts/test/TestRunNotebook1.test2/tmp.scratch/result_1/config.pkl
-$GIT_ROOT/dev_scripts/test/TestRunNotebook1.test2/tmp.scratch/result_1/config.txt
-$GIT_ROOT/dev_scripts/test/TestRunNotebook1.test2/tmp.scratch/result_1/run_notebook.1.log
-$GIT_ROOT/dev_scripts/test/TestRunNotebook1.test2/tmp.scratch/result_1/simple_notebook.1.ipynb
-$GIT_ROOT/dev_scripts/test/TestRunNotebook1.test2/tmp.scratch/result_1/success.txt"""
-        # pylint: disable=line-too-long
         exp_pass = True
-        self._run_notebook_helper(cmd, exp_pass, exp)
+        _run_notebook_helper(self, cmd_opts, exp_pass, self.EXPECTED_OUTCOME)
+
+
+# #############################################################################
+
+
+class TestRunNotebook2(hut.TestCase):
+    """
+    Run experiments that fail.
+    """
+
+    EXPECTED_OUTCOME = r"""# Dir structure
+        $SCRATCH_SPACE
+        $SCRATCH_SPACE/result_0
+        $SCRATCH_SPACE/result_0/config.pkl
+        $SCRATCH_SPACE/result_0/config.txt
+        $SCRATCH_SPACE/result_0/run_notebook.0.log
+        $SCRATCH_SPACE/result_0/simple_notebook.0.ipynb
+        $SCRATCH_SPACE/result_0/success.txt
+        $SCRATCH_SPACE/result_1
+        $SCRATCH_SPACE/result_1/config.pkl
+        $SCRATCH_SPACE/result_1/config.txt
+        $SCRATCH_SPACE/result_1/run_notebook.1.log
+        $SCRATCH_SPACE/result_1/simple_notebook.1.ipynb
+        $SCRATCH_SPACE/result_1/success.txt
+        $SCRATCH_SPACE/result_2
+        $SCRATCH_SPACE/result_2/config.pkl
+        $SCRATCH_SPACE/result_2/config.txt
+        $SCRATCH_SPACE/result_2/run_notebook.2.log"""
 
     @pytest.mark.slow
-    def test3(self) -> None:
+    def test_serial1(self) -> None:
         """
-        Run an experiment with 3 notebooks (with one failing) using 3 threads.
+        Execute:
+        - an experiment with 3 notebooks (with one failing)
+        - serially
+        - aborting on error
         """
-        cmd = [
+        cmd_opts = [
             "--config_builder 'dev_scripts.test.test_run_notebook.build_configs2()'",
             "--num_threads 3",
         ]
-        _LOG.warning("This command is supposed to fail")
-        # pylint: enable=line-too-long
-        exp = r"""# Dir structure
-$GIT_ROOT/dev_scripts/test/TestRunNotebook1.test3/tmp.scratch
-$GIT_ROOT/dev_scripts/test/TestRunNotebook1.test3/tmp.scratch/result_0
-$GIT_ROOT/dev_scripts/test/TestRunNotebook1.test3/tmp.scratch/result_0/config.pkl
-$GIT_ROOT/dev_scripts/test/TestRunNotebook1.test3/tmp.scratch/result_0/config.txt
-$GIT_ROOT/dev_scripts/test/TestRunNotebook1.test3/tmp.scratch/result_0/run_notebook.0.log
-$GIT_ROOT/dev_scripts/test/TestRunNotebook1.test3/tmp.scratch/result_0/simple_notebook.0.ipynb
-$GIT_ROOT/dev_scripts/test/TestRunNotebook1.test3/tmp.scratch/result_0/success.txt
-$GIT_ROOT/dev_scripts/test/TestRunNotebook1.test3/tmp.scratch/result_1
-$GIT_ROOT/dev_scripts/test/TestRunNotebook1.test3/tmp.scratch/result_1/config.pkl
-$GIT_ROOT/dev_scripts/test/TestRunNotebook1.test3/tmp.scratch/result_1/config.txt
-$GIT_ROOT/dev_scripts/test/TestRunNotebook1.test3/tmp.scratch/result_1/run_notebook.1.log
-$GIT_ROOT/dev_scripts/test/TestRunNotebook1.test3/tmp.scratch/result_1/simple_notebook.1.ipynb
-$GIT_ROOT/dev_scripts/test/TestRunNotebook1.test3/tmp.scratch/result_1/success.txt
-$GIT_ROOT/dev_scripts/test/TestRunNotebook1.test3/tmp.scratch/result_2
-$GIT_ROOT/dev_scripts/test/TestRunNotebook1.test3/tmp.scratch/result_2/config.pkl
-$GIT_ROOT/dev_scripts/test/TestRunNotebook1.test3/tmp.scratch/result_2/config.txt
-$GIT_ROOT/dev_scripts/test/TestRunNotebook1.test3/tmp.scratch/result_2/run_notebook.2.log"""
-        # pylint: disable=line-too-long
-        exp_pass = False
-        self._run_notebook_helper(cmd, exp_pass, exp)
-
-    @staticmethod
-    def _get_files() -> Tuple[str, str]:
-        amp_path = git.get_amp_abs_path()
         #
-        exec_file = os.path.join(
-            amp_path, "dev_scripts/notebooks/run_notebook.py"
-        )
-        dbg.dassert_file_exists(exec_file)
-        # This notebook fails/succeeds depending on the return code stored inside
-        # each config.
-        notebook_file = os.path.join(
-            amp_path, "dev_scripts/notebooks/test/simple_notebook.ipynb"
-        )
-        dbg.dassert_file_exists(notebook_file)
-        return exec_file, notebook_file
+        exp_pass = False
+        _LOG.warning("This command is supposed to fail")
+        _run_notebook_helper(self, cmd_opts, exp_pass, self.EXPECTED_OUTCOME)
 
-    def _run_notebook_helper(self, cmd: List[str], exp_pass: bool, exp: str) -> None:
-        # Build command line.
-        dst_dir = self.get_scratch_space()
-        exec_file, notebook_file = self._get_files()
-        cmd_tmp = [
-            f"{exec_file}",
-            f"--dst_dir {dst_dir}",
-            f"--notebook {notebook_file}",
+    @pytest.mark.slow
+    def test_serial2(self) -> None:
+        """
+        Execute:
+        - an experiment with 3 notebooks (with one failing)
+        - serially
+        - skipping on error
+        """
+        cmd_opts = [
+            "--config_builder 'dev_scripts.test.test_run_notebook.build_configs2()'",
+            "--skip_on_error",
+            "--num_threads 3",
         ]
-        cmd_tmp.extend(cmd)
-        cmd = " ".join(cmd_tmp)
-        # Run command.
-        abort_on_error = exp_pass
-        _LOG.debug("exp_pass=%s abort_on_error=%s", exp_pass, abort_on_error)
-        rc = si.system(cmd, abort_on_error=exp_pass, suppress_output=False)
-        if exp_pass:
-            self.assertEqual(rc, 0)
-        else:
-            self.assertNotEqual(rc, 0)
-        # Compute and compare the dir signature.
-        act = hut.get_dir_signature(
-            dst_dir, include_file_content=False, num_lines=None
-        )
-        act = hut.purify_txt_from_client(act)
-        self.assert_equal(act, exp, fuzzy_match=True)
+        #
+        exp_pass = True
+        _run_notebook_helper(self, cmd_opts, exp_pass, self.EXPECTED_OUTCOME)
+
+    @pytest.mark.slow
+    def test_parallel1(self) -> None:
+        """
+        Execute:
+        - an experiment with 3 notebooks (with one failing)
+        - with 2 threads
+        - aborting on error
+        """
+        cmd_opts = [
+            "--config_builder 'dev_scripts.test.test_run_notebook.build_configs2()'",
+            "--num_threads 2",
+        ]
+        #
+        exp_pass = False
+        _LOG.warning("This command is supposed to fail")
+        _run_notebook_helper(self, cmd_opts, exp_pass, self.EXPECTED_OUTCOME)
+
+    @pytest.mark.slow
+    def test_parallel2(self) -> None:
+        """
+        Execute:
+        - an experiment with 3 notebooks (with one failing)
+        - with 2 threads
+        - skipping on error
+        """
+        cmd_opts = [
+            "--config_builder 'dev_scripts.test.test_run_notebook.build_configs2()'",
+            "--skip_on_error",
+            "--num_threads 2",
+        ]
+        #
+        exp_pass = True
+        _run_notebook_helper(self, cmd_opts, exp_pass, self.EXPECTED_OUTCOME)
+
+
+def _get_files() -> Tuple[str, str]:
+    amp_path = git.get_amp_abs_path()
+    #
+    exec_file = os.path.join(amp_path, "dev_scripts/notebooks/run_notebook.py")
+    dbg.dassert_file_exists(exec_file)
+    # This notebook fails/succeeds depending on the return code stored inside
+    # each config.
+    notebook_file = os.path.join(
+        amp_path, "dev_scripts/notebooks/test/simple_notebook.ipynb"
+    )
+    dbg.dassert_file_exists(notebook_file)
+    return exec_file, notebook_file
+
+
+def _run_notebook_helper(
+    self: Any, cmd_opts: List[str], exp_pass: bool, exp: str
+) -> None:
+    # Build command line.
+    dst_dir = self.get_scratch_space()
+    exec_file, notebook_file = _get_files()
+    cmd = [
+        f"{exec_file}",
+        f"--dst_dir {dst_dir}",
+        f"--notebook {notebook_file}",
+    ]
+    run_cmd_line(self, cmd, cmd_opts, dst_dir, exp, exp_pass)
+
+
+# #############################################################################
+
+
+# These are fake config builders used for testing.
 
 
 def _build_config(values: List[bool]) -> List[cconfig.Config]:
     config_template = cconfig.Config()
+    # TODO(gp): -> fail_param
     config_template["fail"] = None
     configs = cconfig.build_multiple_configs(config_template, {("fail",): values})
     # Duplicate configs are not allowed, so we need to add identifiers to make
     # each config unique.
     for i, config in enumerate(configs):
-        config["id"] = i
+        config["id"] = str(i)
+    cast(List[cconfig.Config], configs)
     return configs
 
 
@@ -161,7 +210,7 @@ def build_configs1() -> List[cconfig.Config]:
     """
     Build 2 configs that won't make the notebook to fail.
     """
-    values = (False, False)
+    values = [False, False]
     configs = _build_config(values)
     return configs
 
@@ -170,6 +219,44 @@ def build_configs2() -> List[cconfig.Config]:
     """
     Build 3 configs with one failing.
     """
-    values = (False, False, True)
+    values = [False, False, True]
     configs = _build_config(values)
     return configs
+
+
+# #############################################################################
+
+
+def run_cmd_line(
+    self: Any,
+    cmd: List[str],
+    cmd_opts: List[str],
+    dst_dir: str,
+    exp: str,
+    exp_pass: bool,
+) -> None:
+    # Assemble the command line.
+    cmd.extend(cmd_opts)
+    cmd = " ".join(cmd)
+    # Run command.
+    abort_on_error = exp_pass
+    _LOG.debug("exp_pass=%s abort_on_error=%s", exp_pass, abort_on_error)
+    rc = si.system(cmd, abort_on_error=abort_on_error, suppress_output=False)
+    if exp_pass:
+        self.assertEqual(rc, 0)
+    else:
+        self.assertNotEqual(rc, 0)
+    # Compute and compare the dir signature.
+    act = hut.get_dir_signature(
+        dst_dir, include_file_content=False, num_lines=None
+    )
+    # Remove references like:
+    # $GIT_ROOT/core/dataflow_model/test/TestRunExperiment1.test3/tmp.scratch
+    act = act.replace(self.get_scratch_space(), "$SCRATCH_SPACE")
+    act = hut.purify_txt_from_client(act)
+    # Remove lines like:
+    # $GIT_ROOT/core/dataflow_model/.../log.20210705_100612.txt
+    act = hut.filter_text(r"^.*/log\.\S+\.txt$", act)
+    #
+    exp = hprint.dedent(exp)
+    self.assert_equal(act, exp, fuzzy_match=True)

--- a/helpers/git.py
+++ b/helpers/git.py
@@ -658,8 +658,9 @@ def purify_docker_file_from_git_client(
         file_name = os.path.normpath(file_name)
         found = True
     else:
-        _LOG.warning("Found multiple potential files corresponding to '%s'",
-            file_name)
+        _LOG.warning(
+            "Found multiple potential files corresponding to '%s'", file_name
+        )
         file_name = ",".join(file_names)
         found = False
     _LOG.debug("-> found=%s file_name='%s'", found, file_name)

--- a/helpers/joblib_helpers.py
+++ b/helpers/joblib_helpers.py
@@ -8,7 +8,7 @@ import logging
 import os
 import pprint
 import random
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import joblib
 from tqdm.autonotebook import tqdm
@@ -22,48 +22,182 @@ import helpers.timer as htimer
 _LOG = logging.getLogger(__name__)
 
 # #############################################################################
+# Task
+# #############################################################################
 
-# A task is composed by the parameters (e.g., *args and **kwargs) to call the
-# function.
-TASK = Tuple[Tuple[Any], Dict[str, Any]]
-
-WORKLOAD = Tuple[Callable, str, TASK]
-
-
-# def _func(*args: Any, **kwargs: Any) -> str:
-#     """
-#     Execute the function task.
-#
-#     Note that the function task doesn't have to be the function that we intend to
-#     cache. Calling the function to cache might be a side effect. E.g., if there are
-#     multiple functions that are caching data.
-#
-#     :return: string representing information about the cached function execution.
-#     """
-#     pass
-#
-#
-# def _get_workload(args: argparse.Namespace) -> Tuple[Callable, str, List[hjoblib.TASK], str, str]:
-#     pass
+# A `Task` contains the parameters to pass to the function, in the forms of a
+# tuple of `*args` and `**kwargs`.
+Task = Tuple[Tuple[Any], Dict[str, Any]]
 
 
-def _file_logging_decorator(func: Callable) -> Callable:
+def validate_task(task: Task) -> bool:
     """
-    Decorator to handle execution logging of the function and the
-    abort_on_error behavior.
+    Assert if the task is malformed, otherwise return True.
+    """
+    dbg.dassert_isinstance(task, tuple)
+    dbg.dassert_eq(len(task), 2)
+    args, kwargs = task
+    _LOG.debug("task[0]=%s", str(args))
+    dbg.dassert_isinstance(args, tuple)
+    _LOG.debug("task[1]=%s", str(kwargs))
+    dbg.dassert_isinstance(kwargs, dict)
+    return True
+
+
+def task_to_string(task: Task) -> str:
+    dbg.dassert(validate_task(task))
+    args, kwargs = task
+    txt = []
+    txt.append("args=%s" % pprint.pformat(args))
+    txt.append("kwargs=%s" % pprint.pformat(kwargs))
+    txt = "\n".join(txt)
+    return txt
+
+
+# #############################################################################
+# Workload
+# #############################################################################
+
+# A `Workload` represents multiple executions of a function with different
+# parameters.
+Workload = Tuple[
+    # `func`: the function representing the workload to execute
+    Callable,
+    # `func_name`: the mnemonic name of the function, which is used for debugging info
+    # and for naming the directory storing the cache
+    # - E.g., `vltbut.get_bar_data`
+    # - Note that the `func_name` can be different than the name of `func`
+    #   - E.g., we can call `vltbut.get_bar_data_for_interval` inside `func`,
+    #     in order to create a cache for `vltbut.get_bar_data`, so the cache name
+    #     should be for `vltbut.get_bar_data`
+    str,
+    # `tasks`: a list of (*args, **kwargs) to pass to `func`
+    List[Task],
+]
+
+
+def validate_workload(workload: Workload) -> bool:
+    """
+    Assert if the workload is malformed, otherwise return True.
+    """
+    dbg.dassert_isinstance(workload, tuple)
+    dbg.dassert_eq(len(workload), 3)
+    # Parse workload.
+    workload_func, func_name, tasks = workload
+    # Check each component.
+    dbg.dassert_isinstance(workload_func, Callable)
+    dbg.dassert_isinstance(func_name, str)
+    dbg.dassert_container_type(tasks, List, tuple)
+    dbg.dassert(all(validate_task(task) for task in tasks))
+    return True
+
+
+def randomize_workload(
+    workload: Workload, seed: Optional[int] = None
+) -> Workload:
+    validate_workload(workload)
+    workload_func, func_name, tasks = workload
+    seed = seed or 42
+    random.seed(seed)
+    random.shuffle(tasks)
+    workload = (workload_func, func_name, tasks)
+    validate_workload(workload)
+    return workload
+
+
+def workload_to_string(workload: Workload) -> str:
+    validate_workload(workload)
+    workload_func, func_name, tasks = workload
+    txt = []
+    txt.append("workload_func=%s" % workload_func.__name__)
+    txt.append("func_name=%s" % func_name)
+    for i, task in enumerate(tasks):
+        txt.append("\n" + hprint.frame("Task %s / %s" % (i + 1, len(tasks))))
+        txt.append(task_to_string(task))
+    txt = "\n".join(txt)
+    return txt
+
+
+# #############################################################################
+# Template for functions to execute in parallel.
+# #############################################################################
+
+# NOTE: the workload function:
+# - asserts if there is an error, since the return value is a string with a summary
+#   of the execution
+# - doesn't have to be the function that we intend to cache
+
+
+def _workload_function(*args: Any, **kwargs: Any) -> str:
+    """
+    Execute the function task.
+
+    :raises: in case of error
+    :return: string representing information about the cached function execution.
+    """
+    _ = args
+    incremental = kwargs.pop("incremental")
+    _ = incremental
+    func_output: List[str] = []
+    func_output = "\n".join(func_output)
+    return func_output
+
+
+def _get_workload(
+    # args: argparse.Namespace
+) -> Workload:
+    """
+    Prepare the workload using the parameters from command line.
+    """
+    # _ = args
+
+
+# #############################################################################
+# Layer passing information from `parallel_execute` to the function to execute
+# in parallel.
+# #############################################################################
+
+
+def _parallel_execute_decorator(func: Callable) -> Callable:
+    """
+    Decorator to handle execution logging of the function.
     """
 
-    def wrapper(*args: Any, **kwargs: Any) -> Any:
-        # `start_ts` needs to be before running the function.
-        start_ts = hdatetime.get_timestamp("et")
-        # Extract parameters for the wrapper.
-        task_idx = kwargs.pop("pe_task_idx")
-        task_len = kwargs.pop("pe_task_len")
-        tag = "%s/%s (%s)" % (task_idx + 1, task_len, start_ts)
-        _LOG.info(hprint.frame(tag, "*"))
-        func_name = kwargs.pop("pe_func_name")
-        abort_on_error = kwargs.pop("pe_abort_on_error")
-        log_file = kwargs.pop("pe_log_file")
+    def wrapper(
+        task_idx: int,
+        task_len: int,
+        incremental: bool,
+        abort_on_error: bool,
+        num_attempts: int,
+        log_file: str,
+        #
+        workload_func: Callable,
+        func_name: str,
+        task: Task,
+    ) -> Any:
+        """
+        :param abort_on_error: control whether to abort on `workload_func` function
+            that is failing and asserting
+            - If `workload_func` fails:
+                - if `abort_on_error=True` the exception from `workload_func` is
+                  propagated and the return value is `None`
+                - if `abort_on_error=False` the exception is not propagated, but the
+                  return value is the string representation of the exception
+
+        :return: the return value of the workload function or the exception string
+        """
+        # Validate very carefully all the parameters.
+        dbg.dassert_lte(0, task_idx)
+        dbg.dassert_lt(task_idx, task_len)
+        dbg.dassert_isinstance(incremental, bool)
+        dbg.dassert_isinstance(abort_on_error, bool)
+        dbg.dassert_lte(1, num_attempts)
+        dbg.dassert_isinstance(log_file, str)
+        dbg.dassert_isinstance(workload_func, Callable)
+        dbg.dassert_isinstance(func_name, str)
+        dbg.dassert(validate_task(task))
+        # Redirect the logging output of each task to a different file.
+        # TODO(gp): This file should go in the `task_dst_dir`.
         # log_to_file = True
         log_to_file = False
         if log_to_file:
@@ -80,42 +214,50 @@ def _file_logging_decorator(func: Callable) -> Callable:
 
         # Save some information about the function execution.
         txt = []
-        memento = htimer.dtimer_start(logging.DEBUG, "Execute %s" % func.__name__)
-        txt.append("# task=%s/%s" % (task_idx + 1, task_len))
-        txt.append("func=%s" % func.__name__)
+        # `start_ts` needs to be before running the function.
+        start_ts = hdatetime.get_timestamp("et")
+        tag = "%s/%s (%s)" % (task_idx + 1, task_len, start_ts)
+        txt.append(hprint.frame(tag) + "\n")
+        txt.append("tag=%s" % tag)
+        txt.append("workload_func=%s" % workload_func.__name__)
         txt.append("func_name=%s" % func_name)
-        txt.append("args=\n%s" % hprint.indent(str(args)))
-        txt.append("kwargs=\n%s" % hprint.indent(str(kwargs)))
+        txt.append(task_to_string(task))
+        args, kwargs = task
+        kwargs.update({"incremental": incremental, "num_attempts": num_attempts})
+        memento = htimer.dtimer_start(
+            logging.DEBUG, "Execute '%s'" % workload_func.__name__
+        )
         try:
-            res = func(*args, **kwargs)
+            res = workload_func(*args, **kwargs)
             error = False
-        except RuntimeError as e:
-            txt.append("exception=\n%s" % str(e))
+        except Exception as e:  # pylint: disable=broad-except
+            exception = e
+            txt.append("exception='%s'" % str(e))
             res = None
             error = True
-            _LOG.error("Execution failed:\n%s", txt)
-        txt.append("func_res=\n%s" % hprint.indent(str(res)))
+            _LOG.error("Execution failed")
         msg, elapsed_time = htimer.dtimer_stop(memento)
         _ = msg
+        txt.append("func_res=\n%s" % hprint.indent(str(res)))
         txt.append("elapsed_time_in_secs=%s" % elapsed_time)
         txt.append("start_ts=%s" % start_ts)
         end_ts = hdatetime.get_timestamp("et")
         txt.append("end_ts=%s" % end_ts)
         txt.append("error=%s" % error)
         # Update log file.
-        tag = "%s/%s (%s)" % (task_idx + 1, task_len, start_ts)
-        txt = "\n" + hprint.frame(tag) + "\n" + "\n".join(txt)
+        txt = "\n".join(txt)
         _LOG.debug("txt=\n%s", hprint.indent(txt))
         hio.to_file(log_file, txt, mode="a")
         if error:
-            _LOG.error(msg)
             # The execution wasn't successful.
+            _LOG.error(txt)
             if abort_on_error:
                 _LOG.error("Aborting since abort_on_error=%s", abort_on_error)
-                raise e  # noqa: F821
+                raise exception  # noqa: F821
             _LOG.error(
                 "Continuing execution since abort_on_error=%s", abort_on_error
             )
+            res = str(exception)
         else:
             # The execution was successful.
             pass
@@ -130,136 +272,79 @@ def _file_logging_decorator(func: Callable) -> Callable:
     return wrapper
 
 
-def _decorate_kwargs(
-    kwargs: Dict,
-    task_idx: int,
-    task_len: int,
-    func_name: str,
-    incremental: bool,
-    abort_on_error: bool,
-    log_file: str,
-) -> Dict:
-    """
-    Pass the book-keeping parameters from `parallel_execute()` to the wrapped
-    func.
-    """
-    kwargs = kwargs.copy()
-    # We prepend `pe_` (as in parallel_execution) to avoid collisions.
-    kwargs.update(
-        {
-            "pe_task_idx": task_idx,
-            "pe_task_len": task_len,
-            "pe_func_name": func_name,
-            # This is a parameter for the function, so we don't prepend `pe_`.
-            "incremental": incremental,
-            "pe_abort_on_error": abort_on_error,
-            "pe_log_file": log_file,
-        }
-    )
-    return kwargs
-
-
-# def abort_on_error_handler(func: Callable) -> Callable:
-#     """
-#     Decorator to handle execution logging of the function and the abort_on_error behavior.
-#     """
-#
-#     def wrapper(*args: Any, **kwargs: Any) -> Any:
-#         abort_on_error = kwargs.pop("abort_on_error")
-#         try:
-#             ret = func(*args, **kwargs)
-#         except RuntimeError as e:
-#
-#
-#     wrapper.__name__ = func.__name__
-#     wrapper.__doc__ = func.__doc__
-#     return wrapper
-
-
-def randomize_workload(
-    workload: WORKLOAD, seed: Optional[int] = None
-) -> WORKLOAD:
-    tasks = workload[1]
-    seed = seed or 42
-    random.seed(seed)
-    random.shuffle(tasks)
-    return (workload[0], tasks)
-
-
-def tasks_to_string(func: Callable, func_name: str, tasks: List[TASK]) -> str:
-    dbg.dassert_isinstance(func, Callable)
-    dbg.dassert_isinstance(func_name, str)
-    dbg.dassert_container_type(tasks, List, tuple)
-    txt = []
-    txt.append("func=%s" % func.__name__)
-    txt.append("func_name=%s" % func_name)
-    for i, task in enumerate(tasks):
-        txt.append("\n" + hprint.frame("Task %s / %s" % (i + 1, len(tasks))))
-        txt.append("task=%s" % pprint.pformat(task))
-    txt = "\n".join(txt)
-    return txt
-
-
+# TODO(gp): Pass a `task_dst_dir` to each task so it can write there.
+#  This is a generalization of `experiment_result_dir` for `run_experiment` and
+#  `run_notebook`.
 def parallel_execute(
-    func: Callable,
-    func_name: str,
-    tasks: List[TASK],
+    workload: Workload,
+    # Options for the `parallel_execute` framework.
     dry_run: bool,
-    num_threads: str,
+    num_threads: Union[str, int],
     incremental: bool,
     abort_on_error: bool,
+    num_attempts: int,
     log_file: str,
 ) -> Optional[List[Any]]:
     """
     Run a workload in parallel.
 
-    :param func: function to call in each thread
-    :param func_name: string invocation of the function for logging purposes
-        (e.g., vltbut.get_bar_data_for_date_interval)
-    :param tasks: list of args and kwargs to use when calling `func`
+    :param workload: the workload to execute
+
     :param dry_run: if True, print the workload and exit without executing it
     :param num_threads: joblib parameter to control how many threads to use
     :param incremental: parameter passed to the function to execute, to control if
         we want to re-execute workload already executed or not
-    :param abort_on_error: if True, stop executing the workload if one task asserts,
-        or continue
+    :param abort_on_error: if True, if one task asserts stop executing the workload
+        and return the exception of the failing task
+        - If False, the execution continues
+    :param num_attempts: number of times to attempt running a function before
+        declaring an error
     :param log_file: file used to log information about the execution
 
-    :return: list with the results from executing `func`
+    :return: list with the results from executing `func` or the exception of the
+        failing function
+        - NOTE: if `abort_on_error=True` and one task fails, `joblib` doesn't return
+          the output of the already executed tasks. In this case, the best we can do
+          is to return the exception of the failing task
     """
-    dbg.dassert_isinstance(func, Callable)
-    dbg.dassert_isinstance(func_name, str)
-    dbg.dassert_container_type(tasks, List, tuple)
-    _LOG.info(hprint.to_str("dry_run num_threads incremental abort_on_error"))
-    _LOG.info("Saving log info in '%s'", log_file)
-    _LOG.info("Number of tasks=%s", len(tasks))
+    validate_workload(workload)
+    workload_func, func_name, tasks = workload
+    #
+    _LOG.info(
+        hprint.to_str(
+            "dry_run num_threads incremental num_attempts abort_on_error"
+        )
+    )
     if dry_run:
-        print(tasks_to_string(func, func_name, tasks))
+        print(workload_to_string(workload))
         _LOG.warning("Exiting without executing, as per user request")
         return None
-    # Apply the wrapper to handle `abort_on_error`.
-    wrapped_func = _file_logging_decorator(func)
+    _LOG.info("Saving log info in '%s'", log_file)
+    _LOG.info("Number of tasks=%s", len(tasks))
+    # Apply the wrapper that handles logging of the function.
+    wrapped_func = _parallel_execute_decorator(workload_func)
     # Run.
     task_len = len(tasks)
     if num_threads == "serial":
         res = []
-        for i, task in tqdm(
+        for task_idx, task in tqdm(
             enumerate(tasks), total=len(tasks), desc="Running serial tasks"
         ):
-            _LOG.debug("\n%s", hprint.frame("Task %s / %s" % (i + 1, len(tasks))))
-            _LOG.debug("task=%s", pprint.pformat(task))
+            _LOG.debug(
+                "\n%s", hprint.frame("Task %s / %s" % (task_idx + 1, task_len))
+            )
             # Execute.
             res_tmp = wrapped_func(
-                *task[0],
-                **_decorate_kwargs(
-                    task[1],
-                    i,
-                    task_len,
-                    func_name,
-                    incremental,
-                    abort_on_error,
-                    log_file,
-                ),
+                task_idx,
+                task_len,
+                incremental,
+                abort_on_error,
+                num_attempts,
+                log_file,
+                #
+                workload_func,
+                func_name,
+                task,
             )
             res.append(res_tmp)
     else:
@@ -267,6 +352,7 @@ def parallel_execute(
         # -1 is interpreted by joblib like for all cores.
         _LOG.info("Using %d threads", num_threads)
         # From https://stackoverflow.com/questions/24983493
+        # TODO(gp): It doesn't seem to work.
         tqdm_ = tqdm(
             enumerate(tasks), total=len(tasks), desc="Running parallel tasks"
         )
@@ -275,18 +361,18 @@ def parallel_execute(
         backend = "loky"
         res = joblib.Parallel(n_jobs=num_threads, backend=backend, verbose=200)(
             joblib.delayed(wrapped_func)(
-                *task[0],
-                **_decorate_kwargs(
-                    task[1],
-                    i,
-                    task_len,
-                    func_name,
-                    incremental,
-                    abort_on_error,
-                    log_file,
-                ),
+                task_idx,
+                task_len,
+                incremental,
+                abort_on_error,
+                num_attempts,
+                log_file,
+                #
+                workload_func,
+                func_name,
+                task,
             )
-            for i, task in tqdm_
+            for task_idx, task in tqdm_
         )
     _LOG.info("Saved log info in '%s'", log_file)
     return res

--- a/helpers/lib_tasks.py
+++ b/helpers/lib_tasks.py
@@ -701,8 +701,10 @@ def git_rename_branch(ctx, new_branch_name):  # type: ignore
     #
     old_branch_name = git.get_branch_name(".")
     dbg.dassert_ne(old_branch_name, new_branch_name)
-    msg = (f"Do you want to rename the current branch '{old_branch_name}' to "
-           f"'{new_branch_name}'")
+    msg = (
+        f"Do you want to rename the current branch '{old_branch_name}' to "
+        f"'{new_branch_name}'"
+    )
     hsinte.query_yes_no(msg, abort_on_no=True)
     # https://stackoverflow.com/questions/6591213/how-do-i-rename-a-local-git-branch
     # To rename a local branch:
@@ -713,7 +715,7 @@ def git_rename_branch(ctx, new_branch_name):  # type: ignore
     cmd = f"git push origin {new_branch_name}"
     _run(ctx, cmd)
     # git push origin --delete <oldname>
-    cmd = f"git push origin --delete {branch_name}"
+    cmd = f"git push origin --delete {old_branch_name}"
     _run(ctx, cmd)
     print("Done")
 
@@ -2574,7 +2576,8 @@ def _get_gh_issue_title(issue_id: int, repo_short_name: str) -> str:
         a repo_short_name short name (e.g., "amp")
     """
     repo_full_name_with_host, repo_short_name = _get_repo_full_name_from_cmd(
-        repo_short_name)
+        repo_short_name
+    )
     # > (export NO_COLOR=1; gh issue view 1251 --json title )
     # {"title":"Update GH actions for amp"}
     dbg.dassert_lte(1, issue_id)
@@ -2641,7 +2644,8 @@ def gh_create_pr(  # type: ignore
         # Use the branch name as title.
         title = branch_name
     repo_full_name_with_host, repo_short_name = _get_repo_full_name_from_cmd(
-        repo_short_name)
+        repo_short_name
+    )
     _LOG.info(
         "Creating PR with title '%s' for '%s' in %s",
         title,

--- a/helpers/s3.py
+++ b/helpers/s3.py
@@ -60,7 +60,7 @@ def get_aws_credentials(
                 "'%s' != ''=%s", env_var, os.environ.get(env_var, None) != ""
             )
             dbg.dassert_in(env_var, os.environ)
-        return tuple(os.environ[env_var] for env_var in env_vars)
+        return tuple(os.environ[env_var] for env_var in env_vars)  # type: ignore
     aws_profile = aws_profile or "am"
     _LOG.debug("Getting credentials for aws_profile=%s", aws_profile)
     # > more ~/.aws/credentials
@@ -169,15 +169,18 @@ def _get_boto3_client(aws_profile: Optional[str] = None) -> boto3.client:
     return s3
 
 
-def get_s3fs(aws_profile: Optional[str] = None) -> str:
+def get_s3fs(aws_profile: Optional[str] = None) -> s3fs.core.S3FileSystem:
     # From https://stackoverflow.com/questions/62562945
     aws_access_key_id, aws_secret_access_key, aws_region = get_aws_credentials(
         aws_profile=aws_profile
     )
     _LOG.debug("aws_region=%s", aws_region)
-    s3 = s3fs.core.S3FileSystem(anon=False, key=aws_access_key_id,
-                                secret=aws_secret_access_key,
-                                client_kwargs={'region_name': aws_region})
+    s3 = s3fs.core.S3FileSystem(
+        anon=False,
+        key=aws_access_key_id,
+        secret=aws_secret_access_key,
+        client_kwargs={"region_name": aws_region},
+    )
     return s3
 
 

--- a/helpers/system_interaction.py
+++ b/helpers/system_interaction.py
@@ -571,7 +571,7 @@ def kill_process(
 # #############################################################################
 
 
-def query_yes_no(question: str, abort_on_no: bool) -> bool:
+def query_yes_no(question: str, abort_on_no: bool = True) -> bool:
     """
     Ask a yes/no question via `raw_input()` and return their answer.
 
@@ -655,9 +655,9 @@ def du(path_name: str, human_format: bool = False) -> Union[int, str]:
     # `du` returns size in KB.
     size_in_bytes = int(txt) * 1024
     if human_format:
-        size = hintro.format_size(size_in_bytes)
+        size: str = hintro.format_size(size_in_bytes)
     else:
-        size = size_in_bytes
+        size: int = size_in_bytes
     return size
 
 
@@ -737,40 +737,3 @@ def find_file_with_dir(
     # Select the result based on mode.
     res = select_result_file_from_list(matching_files, mode)
     return res
-
-
-# #############################################################################
-
-
-def is_inside_docker() -> bool:
-    """
-    Return whether we are inside a container or not.
-    """
-    # From https://stackoverflow.com/questions/23513045
-    return os.path.exists("/.dockerenv")
-
-
-def is_inside_ci() -> bool:
-    """
-    Return whether we are running inside the Continuous Integration flow.
-    """
-    if "CI" not in os.environ:
-        ret = False
-    else:
-        ret = os.environ["CI"] != ""
-    return ret
-
-
-def is_running_in_ipynb() -> bool:
-    # From https://stackoverflow.com/questions/15411967
-    try:
-        _ = get_ipython().config  # type: ignore
-        res = True
-    except NameError:
-        res = False
-    return res
-
-
-# TODO(gp): Use this everywhere in the code base.
-def is_running_on_macos() -> bool:
-    return get_os_name() == "Darwin"

--- a/helpers/test/TestPlaybackInputOutput1.test1/output/test.txt
+++ b/helpers/test/TestPlaybackInputOutput1.test1/output/test.txt
@@ -1,4 +1,4 @@
-# Test created for test_playback.get_result_ae.
+# Test created for helpers.test.test_playback.get_result_ae.
 
 import helpers.unit_test as hut
 import jsonpickle

--- a/helpers/test/TestPlaybackInputOutput1.test10/output/test.txt
+++ b/helpers/test/TestPlaybackInputOutput1.test10/output/test.txt
@@ -1,4 +1,4 @@
-# Test created for test_playback.get_result_cs.
+# Test created for helpers.test.test_playback.get_result_cs.
 
 import helpers.unit_test as hut
 import jsonpickle

--- a/helpers/test/TestPlaybackInputOutput1.test11/output/test.txt
+++ b/helpers/test/TestPlaybackInputOutput1.test11/output/test.txt
@@ -1,4 +1,4 @@
-# Test created for test_playback.get_result_cs.
+# Test created for helpers.test.test_playback.get_result_cs.
 
 import helpers.unit_test as hut
 import jsonpickle

--- a/helpers/test/TestPlaybackInputOutput1.test12/output/test.txt
+++ b/helpers/test/TestPlaybackInputOutput1.test12/output/test.txt
@@ -1,4 +1,4 @@
-# Test created for test_playback.get_result_ae.
+# Test created for helpers.test.test_playback.get_result_ae.
 
 import helpers.unit_test as hut
 import jsonpickle

--- a/helpers/test/TestPlaybackInputOutput1.test13/output/test.txt
+++ b/helpers/test/TestPlaybackInputOutput1.test13/output/test.txt
@@ -1,4 +1,4 @@
-# Test created for test_playback.get_result_cs.
+# Test created for helpers.test.test_playback.get_result_cs.
 
 import helpers.unit_test as hut
 import jsonpickle

--- a/helpers/test/TestPlaybackInputOutput1.test14/output/test.txt
+++ b/helpers/test/TestPlaybackInputOutput1.test14/output/test.txt
@@ -1,4 +1,4 @@
-# Test created for test_playback.get_result_ae.
+# Test created for helpers.test.test_playback.get_result_ae.
 
 import helpers.unit_test as hut
 import jsonpickle

--- a/helpers/test/TestPlaybackInputOutput1.test15/output/test.txt
+++ b/helpers/test/TestPlaybackInputOutput1.test15/output/test.txt
@@ -1,4 +1,4 @@
-# Test created for test_playback.get_result_cs.
+# Test created for helpers.test.test_playback.get_result_cs.
 
 import helpers.unit_test as hut
 import jsonpickle

--- a/helpers/test/TestPlaybackInputOutput1.test16/output/test.txt
+++ b/helpers/test/TestPlaybackInputOutput1.test16/output/test.txt
@@ -1,4 +1,4 @@
-# Test created for test_playback.get_result_ae.
+# Test created for helpers.test.test_playback.get_result_ae.
 
 import helpers.unit_test as hut
 import jsonpickle

--- a/helpers/test/TestPlaybackInputOutput1.test17/output/test.txt
+++ b/helpers/test/TestPlaybackInputOutput1.test17/output/test.txt
@@ -1,4 +1,4 @@
-# Test created for test_playback.get_result_cs_none.
+# Test created for helpers.test.test_playback.get_result_cs_none.
 
 import helpers.unit_test as hut
 import jsonpickle

--- a/helpers/test/TestPlaybackInputOutput1.test18/output/test.txt
+++ b/helpers/test/TestPlaybackInputOutput1.test18/output/test.txt
@@ -1,4 +1,4 @@
-# Test created for test_playback.get_result_ae_none.
+# Test created for helpers.test.test_playback.get_result_ae_none.
 
 import helpers.unit_test as hut
 import jsonpickle

--- a/helpers/test/TestPlaybackInputOutput1.test2/output/test.txt
+++ b/helpers/test/TestPlaybackInputOutput1.test2/output/test.txt
@@ -1,4 +1,4 @@
-# Test created for test_playback.get_result_ae.
+# Test created for helpers.test.test_playback.get_result_ae.
 
 import helpers.unit_test as hut
 import jsonpickle

--- a/helpers/test/TestPlaybackInputOutput1.test3/output/test.txt
+++ b/helpers/test/TestPlaybackInputOutput1.test3/output/test.txt
@@ -1,4 +1,4 @@
-# Test created for test_playback.get_result_ae.
+# Test created for helpers.test.test_playback.get_result_ae.
 
 import helpers.unit_test as hut
 import jsonpickle

--- a/helpers/test/TestPlaybackInputOutput1.test4/output/test.txt
+++ b/helpers/test/TestPlaybackInputOutput1.test4/output/test.txt
@@ -1,4 +1,4 @@
-# Test created for test_playback.get_result_ae.
+# Test created for helpers.test.test_playback.get_result_ae.
 
 import helpers.unit_test as hut
 import jsonpickle

--- a/helpers/test/TestPlaybackInputOutput1.test5/output/test.txt
+++ b/helpers/test/TestPlaybackInputOutput1.test5/output/test.txt
@@ -1,4 +1,4 @@
-# Test created for test_playback.get_result_ae.
+# Test created for helpers.test.test_playback.get_result_ae.
 
 import helpers.unit_test as hut
 import jsonpickle

--- a/helpers/test/TestPlaybackInputOutput1.test6/output/test.txt
+++ b/helpers/test/TestPlaybackInputOutput1.test6/output/test.txt
@@ -1,4 +1,4 @@
-# Test created for test_playback.get_result_ae.
+# Test created for helpers.test.test_playback.get_result_ae.
 
 import helpers.unit_test as hut
 import jsonpickle

--- a/helpers/test/TestPlaybackInputOutput1.test7/output/test.txt
+++ b/helpers/test/TestPlaybackInputOutput1.test7/output/test.txt
@@ -1,4 +1,4 @@
-# Test created for test_playback.get_result_cs.
+# Test created for helpers.test.test_playback.get_result_cs.
 
 import helpers.unit_test as hut
 import jsonpickle

--- a/helpers/test/TestPlaybackInputOutput1.test8/output/test.txt
+++ b/helpers/test/TestPlaybackInputOutput1.test8/output/test.txt
@@ -1,4 +1,4 @@
-# Test created for test_playback.get_result_cs.
+# Test created for helpers.test.test_playback.get_result_cs.
 
 import helpers.unit_test as hut
 import jsonpickle

--- a/helpers/test/TestPlaybackInputOutput1.test9/output/test.txt
+++ b/helpers/test/TestPlaybackInputOutput1.test9/output/test.txt
@@ -1,4 +1,4 @@
-# Test created for test_playback.get_result_cs.
+# Test created for helpers.test.test_playback.get_result_cs.
 
 import helpers.unit_test as hut
 import jsonpickle

--- a/helpers/timer.py
+++ b/helpers/timer.py
@@ -159,16 +159,18 @@ def stop_timer(timer: Timer) -> str:
 # Context manager.
 # #############################################################################
 
+
 class TimedScope:
     """
     Measure the execution time of a block of code.
 
-    E.g.,
-    ```
-    with htimer.TimedScope(logging.INFO, "Work") as ts:
-        ... work work work ...
-    ```
+    Use example
+        ```
+        with htimer.TimedScope(logging.INFO, "Work") as ts:
+            ... work work work ...
+        ```
     """
+
     def __init__(self, log_level: int, message: str):
         self._log_level = log_level
         self._message = message
@@ -193,6 +195,7 @@ def timed(f: Callable) -> Callable:
     """
     Decorator adding a timer around the invocation of a function.
     """
+
     def wrapper(*args: Any, **kwargs: Any) -> Any:
         func_name = f.__name__
         #

--- a/helpers/types_helpers.py
+++ b/helpers/types_helpers.py
@@ -1,4 +1,4 @@
 import datetime
 from typing import Union
 
-DATE = Union[str, datetime.date]
+Date = Union[str, datetime.date]

--- a/im/ib/data/extract/gateway/download_data_ib_loop.py
+++ b/im/ib/data/extract/gateway/download_data_ib_loop.py
@@ -421,7 +421,7 @@ def download_ib_data(
     ],
     incremental: bool,
     dst_dir: str,
-    num_threads: str,
+    num_threads: Union[str, int],
 ) -> List[str]:
     _LOG.info("Tasks=%s\n%s", len(tasks), "\n".join(map(str, tasks)))
     hio.create_dir(dst_dir, incremental=True)

--- a/im/ib/data/extract/gateway/unrolling_download_data_ib_loop.py
+++ b/im/ib/data/extract/gateway/unrolling_download_data_ib_loop.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from typing import Any, List, Optional, Tuple
+from typing import Any, List, Optional, Tuple, Union
 
 try:
     import ib_insync
@@ -406,7 +406,7 @@ def get_historical_data(
     what_to_show: str,
     use_rth: bool,
     mode: str,
-    num_threads: str = "serial",
+    num_threads: Union[str, int] = "serial",
     incremental: bool = False,
     dst_dir: Optional[Any] = None,
     use_progress_bar: bool = False,

--- a/mypy.ini
+++ b/mypy.ini
@@ -209,6 +209,9 @@ ignore_missing_imports = True
 [mypy-repo_config]
 ignore_missing_imports = True
 
+[mypy-s3fs]
+ignore_missing_imports = True
+
 [mypy-scipy]
 ignore_missing_imports = True
 


### PR DESCRIPTION
- Improve joblib helpers to not abort when a test fails, but continue, if `abort_on_error=False`
- Add unit tests
- Connect `run_experiment.py` and `run_notebook.py` to the joblib helpers
- Lint