### PR TITLE
Return early when we use clustermap so as to avoid calling ax.tick_pa…

### DIFF
--- a/core/plotting.py
+++ b/core/plotting.py
@@ -929,6 +929,7 @@ def plot_heatmap(
             figsize=figsize,
         )
         g.ax_heatmap.set_title(title)
+        return
     else:
         raise RuntimeError("Invalid mode='%s'" % mode)
     ax.tick_params(axis="y", labelright=True, labelleft=False, labelrotation=0)


### PR DESCRIPTION
…rams.