### PR TITLE
AmpTask1572_Save_experiments_on_S3_02

### DIFF
--- a/core/test/test_config.py
+++ b/core/test/test_config.py
@@ -289,9 +289,11 @@ class Test_nested_config_set1(hut.TestCase):
         """
         Set a key that doesn't exist.
         """
-        config = cconfig.get_config_from_nested_dict({
+        config = cconfig.get_config_from_nested_dict(
+            {
                 "rets/read_data": cconfig.DUMMY,
-                })
+            }
+        )
         exp = r"""
         rets/read_data: __DUMMY__"""
         self.assert_equal(str(config), hprint.dedent(exp))
@@ -307,9 +309,11 @@ class Test_nested_config_set1(hut.TestCase):
         """
         Set a key that already exists.
         """
-        config = cconfig.get_config_from_nested_dict({
+        config = cconfig.get_config_from_nested_dict(
+            {
                 "rets/read_data": cconfig.DUMMY,
-            })
+            }
+        )
         # Overwrite an existing value.
         config["rets/read_data"] = "hello world"
         # Check.
@@ -322,13 +326,15 @@ class Test_nested_config_set1(hut.TestCase):
         """
         Set a key that doesn't exist in the hierarchy.
         """
-        config = cconfig.get_config_from_nested_dict({
+        config = cconfig.get_config_from_nested_dict(
+            {
                 "rets/read_data": cconfig.DUMMY,
-            })
+            }
+        )
         # Set a key that doesn't exist in the hierarchy.
         config["rets/read_data", "source_node_name"] = "data_downloader"
         # This also doesn't work.
-        #config["rets/read_data"]["source_node_name"] = "data_downloader"
+        # config["rets/read_data"]["source_node_name"] = "data_downloader"
         # Check.
         exp = r"""
         rets/read_data: hello world"""
@@ -338,12 +344,15 @@ class Test_nested_config_set1(hut.TestCase):
         """
         Set a key that exist in the hierarchy with a Config.
         """
-        config = cconfig.get_config_from_nested_dict({
+        config = cconfig.get_config_from_nested_dict(
+            {
                 "rets/read_data": cconfig.DUMMY,
-            })
+            }
+        )
         # Assign a config to an existing key.
         config["rets/read_data"] = cconfig.get_config_from_nested_dict(
-            {"source_node_name": "data_downloader"})
+            {"source_node_name": "data_downloader"}
+        )
         # Check.
         exp = r"""
         rets/read_data:
@@ -354,22 +363,26 @@ class Test_nested_config_set1(hut.TestCase):
         """
         Set a key that exists with a complex Config.
         """
-        config = cconfig.get_config_from_nested_dict({
-            "rets/read_data": cconfig.DUMMY,
-        })
-        # Assign a config.
-        config["rets/read_data"] = cconfig.get_config_from_nested_dict({
-            "source_node_name": "data_downloader",
-            "source_node_kwargs": {
-                "exchange": "NASDAQ",
-                "symbol": "AAPL",
-                "root_data_dir": None,
-                "start_date":  datetime.datetime(2020, 1, 4, 9, 30, 0),
-                "end_date": datetime.datetime(2021, 1, 4, 9, 30, 0),
-                "nrows": None,
-                "columns": None,
+        config = cconfig.get_config_from_nested_dict(
+            {
+                "rets/read_data": cconfig.DUMMY,
             }
-        })
+        )
+        # Assign a config.
+        config["rets/read_data"] = cconfig.get_config_from_nested_dict(
+            {
+                "source_node_name": "data_downloader",
+                "source_node_kwargs": {
+                    "exchange": "NASDAQ",
+                    "symbol": "AAPL",
+                    "root_data_dir": None,
+                    "start_date": datetime.datetime(2020, 1, 4, 9, 30, 0),
+                    "end_date": datetime.datetime(2021, 1, 4, 9, 30, 0),
+                    "nrows": None,
+                    "columns": None,
+                },
+            }
+        )
         # Check.
         exp = r"""
         rets/read_data:

--- a/core/test/test_config.py
+++ b/core/test/test_config.py
@@ -1,6 +1,9 @@
+import datetime
 import logging
 import pprint
 from typing import Any
+
+import pytest
 
 import core.config as cconfig
 import helpers.printing as hprint
@@ -33,7 +36,7 @@ def _check_roundtrip_transformation(self_: Any, config: cconfig.Config) -> str:
 # #############################################################################
 
 
-class Test_flat_config1(hut.TestCase):
+class Test_flat_config_set1(hut.TestCase):
     def test_set1(self) -> None:
         """
         Set a key and print a flat config.
@@ -87,6 +90,10 @@ class Test_flat_config1(hut.TestCase):
 
 
 class Test_flat_config_get1(hut.TestCase):
+    """
+    Test `__getitem__()` to `get()`.
+    """
+
     def test_existing_key1(self) -> None:
         """
         Look up an existing key.
@@ -272,6 +279,110 @@ class Test_nested_config_get1(hut.TestCase):
         act = str(cm.exception)
         exp = r'''"key='read_data2' not in '['nrows', 'read_data', 'single_val', 'zscore']'"'''
         self.assert_equal(act, exp, fuzzy_match=True)
+
+
+# #############################################################################
+
+
+class Test_nested_config_set1(hut.TestCase):
+    def test_not_existing_key1(self) -> None:
+        """
+        Set a key that doesn't exist.
+        """
+        config = cconfig.get_config_from_nested_dict({
+                "rets/read_data": cconfig.DUMMY,
+                })
+        exp = r"""
+        rets/read_data: __DUMMY__"""
+        self.assert_equal(str(config), hprint.dedent(exp))
+        # Set a key that doesn't exist.
+        config["rets/hello"] = "world"
+        # Check.
+        exp = r"""
+        rets/read_data: __DUMMY__
+        rets/hello: world"""
+        self.assert_equal(str(config), hprint.dedent(exp))
+
+    def test_existing_key1(self) -> None:
+        """
+        Set a key that already exists.
+        """
+        config = cconfig.get_config_from_nested_dict({
+                "rets/read_data": cconfig.DUMMY,
+            })
+        # Overwrite an existing value.
+        config["rets/read_data"] = "hello world"
+        # Check.
+        exp = r"""
+        rets/read_data: hello world"""
+        self.assert_equal(str(config), hprint.dedent(exp))
+
+    @pytest.mark.skip(reason="See AmpTask1573")
+    def test_existing_key2(self) -> None:
+        """
+        Set a key that doesn't exist in the hierarchy.
+        """
+        config = cconfig.get_config_from_nested_dict({
+                "rets/read_data": cconfig.DUMMY,
+            })
+        # Set a key that doesn't exist in the hierarchy.
+        config["rets/read_data", "source_node_name"] = "data_downloader"
+        # This also doesn't work.
+        #config["rets/read_data"]["source_node_name"] = "data_downloader"
+        # Check.
+        exp = r"""
+        rets/read_data: hello world"""
+        self.assert_equal(str(config), hprint.dedent(exp))
+
+    def test_existing_key3(self) -> None:
+        """
+        Set a key that exist in the hierarchy with a Config.
+        """
+        config = cconfig.get_config_from_nested_dict({
+                "rets/read_data": cconfig.DUMMY,
+            })
+        # Assign a config to an existing key.
+        config["rets/read_data"] = cconfig.get_config_from_nested_dict(
+            {"source_node_name": "data_downloader"})
+        # Check.
+        exp = r"""
+        rets/read_data:
+          source_node_name: data_downloader"""
+        self.assert_equal(str(config), hprint.dedent(exp))
+
+    def test_existing_key4(self) -> None:
+        """
+        Set a key that exists with a complex Config.
+        """
+        config = cconfig.get_config_from_nested_dict({
+            "rets/read_data": cconfig.DUMMY,
+        })
+        # Assign a config.
+        config["rets/read_data"] = cconfig.get_config_from_nested_dict({
+            "source_node_name": "data_downloader",
+            "source_node_kwargs": {
+                "exchange": "NASDAQ",
+                "symbol": "AAPL",
+                "root_data_dir": None,
+                "start_date":  datetime.datetime(2020, 1, 4, 9, 30, 0),
+                "end_date": datetime.datetime(2021, 1, 4, 9, 30, 0),
+                "nrows": None,
+                "columns": None,
+            }
+        })
+        # Check.
+        exp = r"""
+        rets/read_data:
+          source_node_name: data_downloader
+          source_node_kwargs:
+            exchange: NASDAQ
+            symbol: AAPL
+            root_data_dir: None
+            start_date: 2020-01-04 09:30:00
+            end_date: 2021-01-04 09:30:00
+            nrows: None
+            columns: None"""
+        self.assert_equal(str(config), hprint.dedent(exp))
 
 
 # #############################################################################

--- a/helpers/datetime_.py
+++ b/helpers/datetime_.py
@@ -12,7 +12,6 @@ import logging
 import re
 from typing import Callable, Iterable, Optional, Tuple, Union
 
-
 _WARNING = "\033[33mWARNING\033[0m"
 
 
@@ -39,7 +38,7 @@ except ModuleNotFoundError:
     print(_WARNING + f": Can't find {_module}: continuing")
 
 
-import helpers.dbg as dbg
+import helpers.dbg as dbg  # noqa: E402 # pylint: disable=wrong-import-position
 
 _LOG = logging.getLogger(__name__)
 
@@ -60,20 +59,27 @@ StrictDatetime = Union[pd.Timestamp, datetime.datetime]
 
 # TODO(gp): Use a single name of the var (e.g., datetime_) everywhere.
 
-def dassert_is_datetime(datetime_: Datetime):
+
+def dassert_is_datetime(datetime_: Datetime) -> None:
     """
     Assert that `datetime_` is of type `Datetime`.
     """
-    dbg.dassert_isinstance(datetime_, (str, pd.Timestamp, datetime.datetime),
-                           "datetime_='%s' of type '%s' is not a DateTimeType")
+    dbg.dassert_isinstance(
+        datetime_,
+        (str, pd.Timestamp, datetime.datetime),
+        "datetime_='%s' of type '%s' is not a DateTimeType",
+    )
 
 
-def dassert_is_strict_datetime(datetime_: StrictDatetime):
+def dassert_is_strict_datetime(datetime_: StrictDatetime) -> None:
     """
     Assert that `datetime_` is of type `StrictDatetime`.
     """
-    dbg.dassert_isinstance(datetime_, (pd.Timestamp, datetime.datetime),
-                           "datetime_='%s' of type '%s' is not a StrictDateTimeType")
+    dbg.dassert_isinstance(
+        datetime_,
+        (pd.Timestamp, datetime.datetime),
+        "datetime_='%s' of type '%s' is not a StrictDateTimeType",
+    )
 
 
 def to_datetime(datetime_: Datetime) -> datetime.datetime:
@@ -87,25 +93,34 @@ def to_datetime(datetime_: Datetime) -> datetime.datetime:
         datetime_ = pd.Timestamp(datetime_)
     if isinstance(datetime_, pd.Timestamp):
         datetime_ = datetime_.to_pydatetime()
-    return datetime_
+    return datetime_  # type: ignore
 
 
 def dassert_is_tz_naive(datetime_: StrictDatetime) -> None:
     """
-    Assert that the passed timestamp is tz-naive, i.e., doesn't have timezone info.
+    Assert that the passed timestamp is tz-naive, i.e., doesn't have timezone
+    info.
     """
-    dbg.dassert_is(datetime_.tzinfo, None,
-                   "datetime_='%s' is not tz naive", datetime_)
+    dbg.dassert_is(
+        datetime_.tzinfo, None, "datetime_='%s' is not tz naive", datetime_
+    )
 
 
 def dassert_has_tz(datetime_: StrictDatetime) -> None:
     """
     Assert that the passed timestamp has timezone info.
     """
-    dbg.dassert_is_not(datetime_.tzinfo, None, "datetime_='%s' doesn't have timezone info", datetime_)
+    dbg.dassert_is_not(
+        datetime_.tzinfo,
+        None,
+        "datetime_='%s' doesn't have timezone info",
+        datetime_,
+    )
 
 
-def _dassert_has_specified_tz(datetime_: StrictDatetime, tz_zones) -> None:
+def _dassert_has_specified_tz(
+    datetime_: StrictDatetime, tz_zones: Iterable[str]
+) -> None:
     """
     Assert that the passed timestamp has the timezone passed in `tz_zones`.
     """
@@ -122,7 +137,7 @@ def _dassert_has_specified_tz(datetime_: StrictDatetime, tz_zones) -> None:
         type(datetime_),
         tz_info,
         tz_zone,
-        tz_zones
+        tz_zones,
     )
 
 
@@ -130,7 +145,7 @@ def dassert_has_UTC_tz(datetime_: StrictDatetime) -> None:
     """
     Assert that the passed timestamp is UTC.
     """
-    tz_zones = (pytz.timezone("UTC").zone, )
+    tz_zones = (pytz.timezone("UTC").zone,)
     _dassert_has_specified_tz(datetime_, tz_zones)
 
 
@@ -145,7 +160,7 @@ def dassert_has_ET_tz(datetime_: StrictDatetime) -> None:
     _dassert_has_specified_tz(datetime_, tz_zones)
 
 
-# ##############################################################################
+# #############################################################################
 
 
 # TODO(gp): -> get_now_timestamp()
@@ -154,8 +169,6 @@ def get_timestamp(tz: Optional[str] = None) -> str:
         timestamp = datetime.datetime.utcnow()
     elif tz == "et":
         # Return in ET.
-        import pytz
-
         timestamp = datetime.datetime.now(pytz.timezone("EST"))
     else:
         dbg.dassert_is(tz, None)
@@ -163,7 +176,7 @@ def get_timestamp(tz: Optional[str] = None) -> str:
     return timestamp.strftime("%Y%m%d_%H%M%S")
 
 
-# ##############################################################################
+# #############################################################################
 
 
 def to_generalized_datetime(
@@ -243,6 +256,7 @@ def _handle_incorrect_conversions(
                 return modified_x
 
             return "%Y-%m-%d", modify_monthly_date
+    return None
 
 
 def _shift_to_period_end(
@@ -291,6 +305,7 @@ def _shift_to_period_end(
     date_without_month = f"{date[:span[0]]}{date[span[1]:]}".strip()
     if len(date_without_month) == 4 and date_without_month.isdigit():
         return shift_to_month_end
+    return None
 
 
 def _determine_date_format(

--- a/helpers/datetime_.py
+++ b/helpers/datetime_.py
@@ -4,7 +4,7 @@ Import as:
 import helpers.datetime_ as hdatet
 """
 
-# TODO(gp): -> datetime_helpers
+# TODO(gp): -> datetime_helpers (as hdatetime)
 
 import calendar
 import datetime
@@ -12,18 +12,143 @@ import logging
 import re
 from typing import Callable, Iterable, Optional, Tuple, Union
 
-import dateutil.parser as dparse
 
-# TODO(gp): Try to remove / limit this dependency.
-import pandas as pd
+_WARNING = "\033[33mWARNING\033[0m"
+
+
+try:
+    import dateutil.parser as dparse
+except ModuleNotFoundError:
+    _module = "dateutil"
+    print(_WARNING + f": Can't find {_module}: continuing")
+
+
+try:
+    import pandas as pd
+except ModuleNotFoundError:
+    _module = "pandas"
+    print(_WARNING + f": Can't find {_module}: continuing")
+
+
+# TODO(gp): Check if dateutils is equivalent or better so we can simplify the
+#  dependencies.
+try:
+    import pytz
+except ModuleNotFoundError:
+    _module = "pytz"
+    print(_WARNING + f": Can't find {_module}: continuing")
+
 
 import helpers.dbg as dbg
 
 _LOG = logging.getLogger(__name__)
 
-DATETIME_TYPE = Union[pd.Timestamp, datetime.datetime]
+# We use this type to allow flexibility in the interface exposed to client.
+# Typically as soon as we enter functions exposed to users, we call `to_datetime()`
+# to convert the user-provided datetime into a `datetime.datetime` and use only
+# this type in private interfaces.
+# In general it's worth to import this file even for just the type `Datetime`,
+# since typically as soon as the caller uses this type, they also want to use
+# `to_datetime()` and `dassert_*()` functions.
+Datetime = Union[str, pd.Timestamp, datetime.datetime]
+# TODO(gp): Replace _PANDAS_DATE_TYPE with Datetime everywhere
+
+# This type is for stricter interfaces, although it is a bit of a compromise.
+# Either one wants to be flexible and allow everything that can be interpreted as
+# a datetime, or strict and then only the Python type `datetime.datetime` is used.
+StrictDatetime = Union[pd.Timestamp, datetime.datetime]
+
+# TODO(gp): Use a single name of the var (e.g., datetime_) everywhere.
+
+def dassert_is_datetime(datetime_: Datetime):
+    """
+    Assert that `datetime_` is of type `Datetime`.
+    """
+    dbg.dassert_isinstance(datetime_, (str, pd.Timestamp, datetime.datetime),
+                           "datetime_='%s' of type '%s' is not a DateTimeType")
 
 
+def dassert_is_strict_datetime(datetime_: StrictDatetime):
+    """
+    Assert that `datetime_` is of type `StrictDatetime`.
+    """
+    dbg.dassert_isinstance(datetime_, (pd.Timestamp, datetime.datetime),
+                           "datetime_='%s' of type '%s' is not a StrictDateTimeType")
+
+
+def to_datetime(datetime_: Datetime) -> datetime.datetime:
+    """
+    Assert that datetime_ is a possible datetime.
+
+    :return: tz-aware or naive datetime.datetime
+    """
+    dassert_is_datetime(datetime_)
+    if isinstance(datetime_, str):
+        datetime_ = pd.Timestamp(datetime_)
+    if isinstance(datetime_, pd.Timestamp):
+        datetime_ = datetime_.to_pydatetime()
+    return datetime_
+
+
+def dassert_is_tz_naive(datetime_: StrictDatetime) -> None:
+    """
+    Assert that the passed timestamp is tz-naive, i.e., doesn't have timezone info.
+    """
+    dbg.dassert_is(datetime_.tzinfo, None,
+                   "datetime_='%s' is not tz naive", datetime_)
+
+
+def dassert_has_tz(datetime_: StrictDatetime) -> None:
+    """
+    Assert that the passed timestamp has timezone info.
+    """
+    dbg.dassert_is_not(datetime_.tzinfo, None, "datetime_='%s' doesn't have timezone info", datetime_)
+
+
+def _dassert_has_specified_tz(datetime_: StrictDatetime, tz_zones) -> None:
+    """
+    Assert that the passed timestamp has the timezone passed in `tz_zones`.
+    """
+    # Make sure that the passed timestamp has timezone information.
+    dassert_has_tz(datetime_)
+    # Get the timezone.
+    tz_info = datetime_.tzinfo
+    tz_zone = tz_info.zone  # type: ignore
+    has_expected_tz = tz_zone in tz_zones
+    dbg.dassert(
+        has_expected_tz,
+        "datetime_=%s (type=%s) tz_info=%s tz_info.zone=%s instead of tz_zones=%s",
+        datetime_,
+        type(datetime_),
+        tz_info,
+        tz_zone,
+        tz_zones
+    )
+
+
+def dassert_has_UTC_tz(datetime_: StrictDatetime) -> None:
+    """
+    Assert that the passed timestamp is UTC.
+    """
+    tz_zones = (pytz.timezone("UTC").zone, )
+    _dassert_has_specified_tz(datetime_, tz_zones)
+
+
+def dassert_has_ET_tz(datetime_: StrictDatetime) -> None:
+    """
+    Assert that the passed timestamp is Eastern Time (ET).
+    """
+    tz_zones = (
+        pytz.timezone("US/Eastern").zone,
+        pytz.timezone("America/New_York").zone,
+    )
+    _dassert_has_specified_tz(datetime_, tz_zones)
+
+
+# ##############################################################################
+
+
+# TODO(gp): -> get_now_timestamp()
 def get_timestamp(tz: Optional[str] = None) -> str:
     if tz == "utc":
         timestamp = datetime.datetime.utcnow()
@@ -38,44 +163,10 @@ def get_timestamp(tz: Optional[str] = None) -> str:
     return timestamp.strftime("%Y%m%d_%H%M%S")
 
 
-def check_et_timezone(dt: DATETIME_TYPE) -> bool:
-    # TODO(gp): Check if dateutils is better.
-    import pytz
-
-    tzinfo = dt.tzinfo
-    dbg.dassert(tzinfo, "Timestamp should be tz-aware.")
-    zone = tzinfo.zone  # type: ignore
-    ret = zone in (
-        pytz.timezone("US/Eastern").zone,
-        pytz.timezone("America/New_York").zone,
-    )
-    dbg.dassert(
-        ret,
-        "dt=%s (type=%s) tzinfo=%s (type=%s) tzinfo.zone=%s",
-        dt,
-        type(dt),
-        tzinfo,
-        type(tzinfo),
-        zone,
-    )
-    return True
+# ##############################################################################
 
 
-def validate_datetime(timestamp: DATETIME_TYPE) -> pd.Timestamp:
-    """
-    Assert that timestamp is in UTC, convert to pd.Timestamp.
-
-    :param timestamp: datetime object or pd.Timestamp
-    :return: tz-aware pd.Timestamp
-    """
-    dbg.dassert_type_in(timestamp, [pd.Timestamp, datetime.datetime])
-    pd_timestamp = pd.Timestamp(timestamp)
-    dbg.dassert(pd_timestamp.tzinfo, "Timestamp should be tz-aware.")
-    dbg.dassert_eq(pd_timestamp.tzinfo.zone, "UTC", "Timezone should be UTC.")
-    return pd_timestamp
-
-
-def to_datetime(
+def to_generalized_datetime(
     dates: Union[pd.Series, pd.Index], date_standard: Optional[str] = None
 ) -> Union[pd.Series, pd.Index]:
     """
@@ -156,7 +247,7 @@ def _handle_incorrect_conversions(
 
 def _shift_to_period_end(
     date: str,
-) -> Optional[Callable[[DATETIME_TYPE], DATETIME_TYPE]]:
+) -> Optional[Callable[[StrictDatetime], StrictDatetime]]:
     """
     Get function to shift the dates to the end of period.
 
@@ -165,13 +256,13 @@ def _shift_to_period_end(
         shift is needed
     """
 
-    def shift_to_month_end(x: DATETIME_TYPE) -> DATETIME_TYPE:
+    def shift_to_month_end(x: StrictDatetime) -> StrictDatetime:
         return x + pd.offsets.MonthEnd(0)
 
-    def shift_to_quarter_end(x: DATETIME_TYPE) -> DATETIME_TYPE:
+    def shift_to_quarter_end(x: StrictDatetime) -> StrictDatetime:
         return x + pd.offsets.QuarterEnd(0)
 
-    def shift_to_year_end(x: DATETIME_TYPE) -> DATETIME_TYPE:
+    def shift_to_year_end(x: StrictDatetime) -> StrictDatetime:
         return x + pd.offsets.YearEnd(0)
 
     if date[:4].isdigit():

--- a/helpers/test/test_datetime_.py
+++ b/helpers/test/test_datetime_.py
@@ -10,7 +10,7 @@ import helpers.unit_test as hut
 _LOG = logging.getLogger(__name__)
 
 
-# ##############################################################################
+# #############################################################################
 
 _STR_TS_NAIVE = "2021-01-04 09:30:00"
 _STR_TS_UTC = "2021-01-04 09:30:00-00:00"
@@ -26,7 +26,6 @@ _DT_DT_ET = pytz.timezone("US/Eastern").localize(_DT_DT_NAIVE)
 
 
 class Test_dassert_tz1(hut.TestCase):
-
     def test_datetime_conversions(self) -> None:
         # Get a tz-naive datetime.
         dt = datetime.datetime(2020, 1, 5, 9, 30, 0)
@@ -54,15 +53,13 @@ class Test_dassert_tz1(hut.TestCase):
             _STR_TS_NAIVE,
             _STR_TS_UTC,
             _STR_TS_ET,
-
             _PD_TS_NAIVE,
             _PD_TS_UTC,
             _PD_TS_ET,
-
             _DT_DT_NAIVE,
             _DT_DT_UTC,
             _DT_DT_ET,
-            ]:
+        ]:
             hdatetime.dassert_is_datetime(obj)
 
     def test_dassert_is_datetime_assert1(self) -> None:
@@ -134,7 +131,7 @@ datetime_='%s' of type '%s' is not a DateTimeType
             self.assertEqual(str(act), str(exp))
 
 
-# ##############################################################################
+# #############################################################################
 
 
 class Test_to_generalized_datetime(hut.TestCase):

--- a/helpers/test/test_datetime_.py
+++ b/helpers/test/test_datetime_.py
@@ -1,17 +1,146 @@
+import datetime
 import logging
 
 import pandas as pd
+import pytz
 
-import helpers.datetime_ as hdatet
+import helpers.datetime_ as hdatetime
 import helpers.unit_test as hut
 
 _LOG = logging.getLogger(__name__)
 
 
-class Test_to_datetime(hut.TestCase):
+# ##############################################################################
+
+_STR_TS_NAIVE = "2021-01-04 09:30:00"
+_STR_TS_UTC = "2021-01-04 09:30:00-00:00"
+_STR_TS_ET = "2021-01-04 09:30:00-05:00"
+
+_PD_TS_NAIVE = pd.Timestamp("2021-01-04 09:30:00")
+_PD_TS_UTC = pd.Timestamp("2021-01-04 09:30:00-00:00")
+_PD_TS_ET = pd.Timestamp("2021-01-04 09:30:00-05:00")
+
+_DT_DT_NAIVE = datetime.datetime(2021, 1, 4, 9, 30, 0)
+_DT_DT_UTC = pytz.timezone("UTC").localize(_DT_DT_NAIVE)
+_DT_DT_ET = pytz.timezone("US/Eastern").localize(_DT_DT_NAIVE)
+
+
+class Test_dassert_tz1(hut.TestCase):
+
+    def test_datetime_conversions(self) -> None:
+        # Get a tz-naive datetime.
+        dt = datetime.datetime(2020, 1, 5, 9, 30, 0)
+        hdatetime.dassert_is_tz_naive(dt)
+        # Localize it to UTC.
+        dt_utc = pytz.timezone("UTC").localize(dt)
+        hdatetime.dassert_has_tz(dt_utc)
+        hdatetime.dassert_has_UTC_tz(dt_utc)
+        # Convert to ET.
+        dt_et = dt_utc.astimezone(pytz.timezone("US/Eastern"))
+        hdatetime.dassert_has_tz(dt_et)
+        hdatetime.dassert_has_ET_tz(dt_et)
+        # Convert it back to UTC.
+        dt_utc2 = dt_et.astimezone(pytz.timezone("UTC"))
+        hdatetime.dassert_has_tz(dt_utc2)
+        hdatetime.dassert_has_UTC_tz(dt_utc2)
+        self.assertEqual(dt_utc, dt_utc2)
+        # Make it naive.
+        dt2 = dt_utc2.replace(tzinfo=None)
+        hdatetime.dassert_is_tz_naive(dt2)
+        self.assertEqual(dt, dt2)
+
+    def test_dassert_is_datetime1(self) -> None:
+        for obj in [
+            _STR_TS_NAIVE,
+            _STR_TS_UTC,
+            _STR_TS_ET,
+
+            _PD_TS_NAIVE,
+            _PD_TS_UTC,
+            _PD_TS_ET,
+
+            _DT_DT_NAIVE,
+            _DT_DT_UTC,
+            _DT_DT_ET,
+            ]:
+            hdatetime.dassert_is_datetime(obj)
+
+    def test_dassert_is_datetime_assert1(self) -> None:
+        datetime_ = 5
+        with self.assertRaises(AssertionError) as cm:
+            hdatetime.dassert_is_datetime(datetime_)
+        act = str(cm.exception)
+        exp = r"""
+* Failed assertion *
+instance of '5' is '<class 'int'>' instead of '(<class 'str'>, <class 'pandas._libs.tslibs.timestamps.Timestamp'>, <class 'datetime.datetime'>)'
+Caught assertion while formatting message:
+'not enough arguments for format string'
+datetime_='%s' of type '%s' is not a DateTimeType
+"""
+        self.assert_equal(act, exp, fuzzy_match=True)
+
+    def test_to_datetime1(self) -> None:
+        """
+        Apply `to_datetime` to a naive datetime.
+        """
+        for obj in [
+            _STR_TS_NAIVE,
+            _PD_TS_NAIVE,
+            _DT_DT_NAIVE,
+        ]:
+            _LOG.debug("obj='%s' type='%s'", obj, type(obj))
+            act = hdatetime.to_datetime(obj)
+            exp = _DT_DT_NAIVE
+            self.assertEqual(act, exp)
+            # Check the tz info.
+            hdatetime.dassert_is_tz_naive(act)
+            with self.assertRaises(AssertionError):
+                hdatetime.dassert_has_tz(act)
+                hdatetime.dassert_has_UTC_tz(act)
+                hdatetime.dassert_has_ET_tz(act)
+
+    def test_to_datetime2(self) -> None:
+        """
+        Apply `to_datetime` to a UTC datetime.
+        """
+        for obj in [
+            _STR_TS_UTC,
+            _PD_TS_UTC,
+            _DT_DT_UTC,
+        ]:
+            _LOG.debug("obj='%s' type='%s'", obj, type(obj))
+            act = hdatetime.to_datetime(obj)
+            exp = _DT_DT_UTC
+            self.assertEqual(act, exp)
+            # Check the tz info.
+            hdatetime.dassert_has_tz(act)
+            hdatetime.dassert_has_UTC_tz(act)
+            with self.assertRaises(AssertionError):
+                hdatetime.dassert_is_tz_naive(act)
+                hdatetime.dassert_has_ET_tz(act)
+
+    def test_to_datetime3(self) -> None:
+        """
+        Apply `to_datetime` to an ET datetime.
+        """
+        for obj in [
+            _STR_TS_ET,
+            _PD_TS_ET,
+            _DT_DT_ET,
+        ]:
+            _LOG.debug("obj='%s' type='%s'", obj, type(obj))
+            act = hdatetime.to_datetime(obj)
+            exp = _DT_DT_ET
+            self.assertEqual(str(act), str(exp))
+
+
+# ##############################################################################
+
+
+class Test_to_generalized_datetime(hut.TestCase):
     def test_srs1(self) -> None:
         srs = pd.Series(["2010-01-01", "2010-01-02"])
-        actual = hdatet.to_datetime(srs)
+        actual = hdatetime.to_generalized_datetime(srs)
         expected = pd.Series(
             [pd.Timestamp("2010-01-01"), pd.Timestamp("2010-01-02")]
         )
@@ -19,7 +148,7 @@ class Test_to_datetime(hut.TestCase):
 
     def test_index1(self) -> None:
         idx = pd.Index(["2010-01-01", "2010-01-02"])
-        actual = hdatet.to_datetime(idx)
+        actual = hdatetime.to_generalized_datetime(idx)
         expected = pd.Index(
             [pd.Timestamp("2010-01-01"), pd.Timestamp("2010-01-02")]
         )
@@ -27,7 +156,7 @@ class Test_to_datetime(hut.TestCase):
 
     def test_daily1(self) -> None:
         srs = pd.Series(["1 Jan 2010", "2 Jan 2010"])
-        actual = hdatet.to_datetime(srs)
+        actual = hdatetime.to_generalized_datetime(srs)
         expected = pd.Series(
             [pd.Timestamp("2010-01-01"), pd.Timestamp("2010-01-02")]
         )
@@ -35,7 +164,7 @@ class Test_to_datetime(hut.TestCase):
 
     def test_weekly1(self) -> None:
         srs = pd.Series(["2021-W14", "2021-W15"])
-        actual = hdatet.to_datetime(srs)
+        actual = hdatetime.to_generalized_datetime(srs)
         expected = pd.Series(
             [pd.Timestamp("2021-04-10"), pd.Timestamp("2021-04-17")]
         )
@@ -43,7 +172,7 @@ class Test_to_datetime(hut.TestCase):
 
     def test_semiannual1(self) -> None:
         srs = pd.Series(["2021-S1", "2021-S2"])
-        actual = hdatet.to_datetime(srs)
+        actual = hdatetime.to_generalized_datetime(srs)
         expected = pd.Series(
             [pd.Timestamp("2021-06-30"), pd.Timestamp("2021-12-31")]
         )
@@ -51,7 +180,7 @@ class Test_to_datetime(hut.TestCase):
 
     def test_semiannual2(self) -> None:
         srs = pd.Series(["2021/S1", "2021/S2"])
-        actual = hdatet.to_datetime(srs)
+        actual = hdatetime.to_generalized_datetime(srs)
         expected = pd.Series(
             [pd.Timestamp("2021-06-30"), pd.Timestamp("2021-12-31")]
         )
@@ -59,7 +188,7 @@ class Test_to_datetime(hut.TestCase):
 
     def test_bimonthly1(self) -> None:
         srs = pd.Series(["2021-B1", "2021-B2"])
-        actual = hdatet.to_datetime(srs)
+        actual = hdatetime.to_generalized_datetime(srs)
         expected = pd.Series(
             [pd.Timestamp("2021-01-01"), pd.Timestamp("2021-03-01")]
         )
@@ -67,7 +196,7 @@ class Test_to_datetime(hut.TestCase):
 
     def test_monthly1(self) -> None:
         srs = pd.Series(["2020-M1", "2020-M2"])
-        actual = hdatet.to_datetime(srs)
+        actual = hdatetime.to_generalized_datetime(srs)
         expected = pd.Series(
             [pd.Timestamp("2020-01-31"), pd.Timestamp("2020-02-29")]
         )
@@ -75,7 +204,7 @@ class Test_to_datetime(hut.TestCase):
 
     def test_monthly2(self) -> None:
         srs = pd.Series(["2020M01", "2020M02"])
-        actual = hdatet.to_datetime(srs)
+        actual = hdatetime.to_generalized_datetime(srs)
         expected = pd.Series(
             [pd.Timestamp("2020-01-31"), pd.Timestamp("2020-02-29")]
         )
@@ -83,7 +212,7 @@ class Test_to_datetime(hut.TestCase):
 
     def test_monthly3(self) -> None:
         srs = pd.Series(["2020-01", "2020-02"])
-        actual = hdatet.to_datetime(srs)
+        actual = hdatetime.to_generalized_datetime(srs)
         expected = pd.Series(
             [pd.Timestamp("2020-01-31"), pd.Timestamp("2020-02-29")]
         )
@@ -91,7 +220,7 @@ class Test_to_datetime(hut.TestCase):
 
     def test_monthly4(self) -> None:
         srs = pd.Series(["2020 Jan", "2020 Feb"])
-        actual = hdatet.to_datetime(srs)
+        actual = hdatetime.to_generalized_datetime(srs)
         expected = pd.Series(
             [pd.Timestamp("2020-01-31"), pd.Timestamp("2020-02-29")]
         )
@@ -99,7 +228,7 @@ class Test_to_datetime(hut.TestCase):
 
     def test_monthly5(self) -> None:
         srs = pd.Series(["January 2020", "February 2020"])
-        actual = hdatet.to_datetime(srs)
+        actual = hdatetime.to_generalized_datetime(srs)
         expected = pd.Series(
             [pd.Timestamp("2020-01-31"), pd.Timestamp("2020-02-29")]
         )
@@ -107,7 +236,7 @@ class Test_to_datetime(hut.TestCase):
 
     def test_quarterly1(self) -> None:
         srs = pd.Series(["2020-Q1", "2020-Q2"])
-        actual = hdatet.to_datetime(srs)
+        actual = hdatetime.to_generalized_datetime(srs)
         expected = pd.Series(
             [pd.Timestamp("2020-03-31"), pd.Timestamp("2020-06-30")]
         )
@@ -115,7 +244,7 @@ class Test_to_datetime(hut.TestCase):
 
     def test_quarterly2(self) -> None:
         srs = pd.Series(["2020Q1", "2020Q2"])
-        actual = hdatet.to_datetime(srs)
+        actual = hdatetime.to_generalized_datetime(srs)
         expected = pd.Series(
             [pd.Timestamp("2020-03-31"), pd.Timestamp("2020-06-30")]
         )
@@ -123,7 +252,7 @@ class Test_to_datetime(hut.TestCase):
 
     def test_quarterly3(self) -> None:
         srs = pd.Series(["Q1 2020", "Q2 2020"])
-        actual = hdatet.to_datetime(srs)
+        actual = hdatetime.to_generalized_datetime(srs)
         expected = pd.Series(
             [pd.Timestamp("2020-03-31"), pd.Timestamp("2020-06-30")]
         )
@@ -131,7 +260,7 @@ class Test_to_datetime(hut.TestCase):
 
     def test_annual1(self) -> None:
         srs = pd.Series(["2021", "2022"])
-        actual = hdatet.to_datetime(srs)
+        actual = hdatetime.to_generalized_datetime(srs)
         expected = pd.Series(
             [pd.Timestamp("2021-12-31"), pd.Timestamp("2022-12-31")]
         )


### PR DESCRIPTION
- `core/test/test_config.py`
- Add unit tests for AmpTask1573 and for setting params in config

- `helpers/datetime_.py`, `helpers/test/test_datetime_.py`
   - Factor out a common set of functions about timezone checking and management in helpers/datetime_.py