### PR TITLE
Amp task1581 update plotting defaults

### DIFF
--- a/core/dataflow_model/model_plotter.py
+++ b/core/dataflow_model/model_plotter.py
@@ -166,7 +166,7 @@ class ModelPlotter:
             rets = rets.resample(rule=resample_rule).sum(min_count=1)
         # Set kwargs.
         plot_cumulative_returns_kwargs = plot_cumulative_returns_kwargs or {
-            "mode": "pct",
+            "mode": "log",
             "unit": "%",
         }
         plot_rolling_beta_kwargs = plot_rolling_beta_kwargs or {"window": 52}

--- a/core/dataflow_model/notebooks/Master_model_analyzer.py
+++ b/core/dataflow_model/notebooks/Master_model_analyzer.py
@@ -91,7 +91,7 @@ plotter = modplot.ModelPlotter(evaluator)
 pnl_stats = evaluator.calculate_stats(
     mode=eval_config["mode"], target_volatility=eval_config["target_volatility"]
 )
-display(pnl_stats.loc[["signal_quality", "correlation"]])
+display(pnl_stats)
 
 # %% [markdown]
 # ## Model selection
@@ -180,6 +180,9 @@ plotter.plot_rets_and_vol(
     mode=eval_config["mode"],
     target_volatility=eval_config["target_volatility"],
 )
+
+# %%
+assert(0)
 
 # %%
 plotter.plot_positions(


### PR DESCRIPTION
- Replace "pct" with "log" for consistency and better scale properties
- Display full stats table in analyzer notebook by default
- Do not run by default the slow / not always interesting or relevant plots in the analyzer notebook