### PR TITLE
LimeTask181_Error_when_attempting_to_load_artifacts_with_one_result

### DIFF
--- a/core/dataflow/result_bundle.py
+++ b/core/dataflow/result_bundle.py
@@ -287,7 +287,8 @@ class ResultBundle(abc.ABC):
                 obj = hpickle.from_pickle(file_name, log_level=logging.DEBUG)
                 # TODO(gp): This is a workaround waiting for LimeTask164.
                 #  We load 200MB of data and then discard 198MB.
-                obj.payload = None
+                if hasattr(obj, "payload"):
+                    obj.payload = None
                 dbg.dassert_isinstance(obj, ResultBundle)
             # Load the `result_df` as parquet.
             file_name_pq = io_.change_filename_extension(file_name, "pkl", "pq")

--- a/core/dataflow_model/model_evaluator.py
+++ b/core/dataflow_model/model_evaluator.py
@@ -258,6 +258,7 @@ class StrategyEvaluator:
             pnl_dict = pnl_dict_pivoted
         else:
             raise ValueError("Invalid key_type='%s'" % key_type)
+        _LOG.info("memory_usage=%s", dbg.get_memory_usage_as_str(None))
         return pnl_dict
 
     def calculate_stats(
@@ -303,6 +304,7 @@ class StrategyEvaluator:
             [adj_pvals.to_frame().transpose()], keys=["signal_quality"]
         )
         stats_df = pd.concat([stats_df, adj_pvals], axis=0)
+        _LOG.info("memory_usage=%s", dbg.get_memory_usage_as_str(None))
         return stats_df
 
 
@@ -538,6 +540,7 @@ class ModelEvaluator:
             positions_col="positions",
             pnl_col="pnl",
         )
+        _LOG.info("memory_usage=%s", dbg.get_memory_usage_as_str(None))
         return pnl_srs, pos_srs, aggregate_stats
 
     # TODO(gp): This is second.
@@ -595,6 +598,7 @@ class ModelEvaluator:
             [adj_pvals.to_frame().transpose()], keys=["signal_quality"]
         )
         stats_df = pd.concat([stats_df, adj_pvals], axis=0)
+        _LOG.info("memory_usage=%s", dbg.get_memory_usage_as_str(None))
         return stats_df
 
     # TODO(gp): This is first.
@@ -678,6 +682,7 @@ class ModelEvaluator:
             )
         _LOG.debug("Trim pnl_dict")
         pnl_dict = self._trim_time_range(pnl_dict, mode=mode)
+        _LOG.info("memory_usage=%s", dbg.get_memory_usage_as_str(None))
         return pnl_dict
 
     # TODO(gp): Maybe trim when they are generated so we can discard.

--- a/core/dataflow_model/notebooks/Master_model_analyzer.ipynb
+++ b/core/dataflow_model/notebooks/Master_model_analyzer.ipynb
@@ -27,8 +27,8 @@
    "id": "abf41299",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2021-09-19T17:38:42.224116Z",
-     "start_time": "2021-09-19T17:38:39.142499Z"
+     "end_time": "2021-09-21T22:19:52.975008Z",
+     "start_time": "2021-09-21T22:19:52.868573Z"
     }
    },
    "outputs": [],
@@ -41,7 +41,6 @@
     "import core.config as cconfig\n",
     "import core.dataflow_model.model_evaluator as modeval\n",
     "import core.dataflow_model.model_plotter as modplot\n",
-    "import core.dataflow_model.utils as cdmu\n",
     "import helpers.dbg as dbg\n",
     "import helpers.printing as hprint"
    ]
@@ -52,8 +51,8 @@
    "id": "eee79ad8",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2021-09-19T17:38:42.278006Z",
-     "start_time": "2021-09-19T17:38:42.226279Z"
+     "end_time": "2021-09-21T22:19:55.009138Z",
+     "start_time": "2021-09-21T22:19:54.972438Z"
     }
    },
    "outputs": [],
@@ -82,8 +81,8 @@
    "id": "a9c3584e",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2021-09-19T18:25:41.340921Z",
-     "start_time": "2021-09-19T18:25:41.302516Z"
+     "end_time": "2021-09-21T22:19:56.892027Z",
+     "start_time": "2021-09-21T22:19:56.857737Z"
     }
    },
    "outputs": [],
@@ -94,7 +93,8 @@
     "# Override config.\n",
     "if eval_config is None:\n",
     "    # experiment_dir = \"s3://eglp-spm-sasm/experiments/experiment.RH2Ef.v1_9-all.5T.20210831-004747.run1.tgz\"\n",
-    "    experiment_dir = \"/app/oos_experiment.RH2Eg.v2_0-top100.5T.run1_test\"\n",
+    "    #experiment_dir = \"/cache/experiments/oos_experiment.RH1E.v2_0-top100.5T\"\n",
+    "    experiment_dir = \"/cache/experiments/experiment.RH4E.v2_0-top10.5T\"\n",
     "    aws_profile = None\n",
     "    selected_idxs = None\n",
     "\n",
@@ -138,8 +138,8 @@
    "id": "371704c7",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2021-09-19T18:25:46.681236Z",
-     "start_time": "2021-09-19T18:25:46.466038Z"
+     "end_time": "2021-09-21T22:20:03.588356Z",
+     "start_time": "2021-09-21T22:20:03.328782Z"
     },
     "scrolled": false
    },
@@ -166,8 +166,8 @@
    "id": "f353ea8a",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2021-09-19T18:25:55.717352Z",
-     "start_time": "2021-09-19T18:25:49.545056Z"
+     "end_time": "2021-09-21T15:54:39.933619Z",
+     "start_time": "2021-09-21T15:49:39.611475Z"
     },
     "scrolled": false
    },
@@ -193,8 +193,8 @@
    "id": "b6fecfb5",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2021-09-09T21:49:25.699435Z",
-     "start_time": "2021-09-09T21:49:25.699423Z"
+     "end_time": "2021-09-21T15:57:25.914324Z",
+     "start_time": "2021-09-21T15:57:20.407996Z"
     }
    },
    "outputs": [],
@@ -210,8 +210,8 @@
    "id": "b5b44ae9",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2021-09-09T21:49:25.700640Z",
-     "start_time": "2021-09-09T21:49:25.700629Z"
+     "end_time": "2021-09-21T15:57:25.948690Z",
+     "start_time": "2021-09-21T15:57:25.916052Z"
     }
    },
    "outputs": [],
@@ -237,13 +237,13 @@
    "id": "1736ff88",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2021-09-19T22:36:20.187730Z",
-     "start_time": "2021-09-19T22:36:14.506229Z"
+     "end_time": "2021-09-21T15:57:45.048261Z",
+     "start_time": "2021-09-21T15:57:25.950023Z"
     }
    },
    "outputs": [],
    "source": [
-    "#selected = None\n",
+    "# selected = None\n",
     "plotter.plot_multiple_pnls(\n",
     "    keys=selected,\n",
     "    resample_rule=eval_config[\"resample_rule\"],\n",
@@ -265,8 +265,8 @@
    "id": "1d0698e1",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2021-09-09T21:49:25.702985Z",
-     "start_time": "2021-09-09T21:49:25.702973Z"
+     "end_time": "2021-09-21T15:57:53.994225Z",
+     "start_time": "2021-09-21T15:57:45.050262Z"
     }
    },
    "outputs": [],
@@ -284,8 +284,8 @@
    "id": "749d6378",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2021-09-09T21:49:25.704023Z",
-     "start_time": "2021-09-09T21:49:25.704012Z"
+     "end_time": "2021-09-21T15:58:02.512583Z",
+     "start_time": "2021-09-21T15:57:53.995788Z"
     }
    },
    "outputs": [],
@@ -311,8 +311,8 @@
    "id": "c5e7659a",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2021-09-09T21:49:25.705010Z",
-     "start_time": "2021-09-09T21:49:25.705000Z"
+     "end_time": "2021-09-21T15:58:11.518436Z",
+     "start_time": "2021-09-21T15:58:02.513994Z"
     }
    },
    "outputs": [],
@@ -330,8 +330,8 @@
    "id": "b7938396",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2021-09-09T21:49:25.705975Z",
-     "start_time": "2021-09-09T21:49:25.705963Z"
+     "end_time": "2021-09-21T15:58:19.759169Z",
+     "start_time": "2021-09-21T15:58:11.519982Z"
     }
    },
    "outputs": [],
@@ -357,8 +357,8 @@
    "id": "c23ae6ee",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2021-09-19T22:36:53.144680Z",
-     "start_time": "2021-09-19T22:36:48.409710Z"
+     "end_time": "2021-09-21T15:58:29.805658Z",
+     "start_time": "2021-09-21T15:58:19.760503Z"
     }
    },
    "outputs": [],
@@ -377,8 +377,8 @@
    "id": "c61ac477",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2021-09-09T21:49:25.708523Z",
-     "start_time": "2021-09-09T21:49:25.708510Z"
+     "end_time": "2021-09-21T15:58:40.407680Z",
+     "start_time": "2021-09-21T15:58:29.807184Z"
     }
    },
    "outputs": [],
@@ -392,8 +392,8 @@
    "id": "e6ab0618",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2021-09-09T21:49:25.709726Z",
-     "start_time": "2021-09-09T21:49:25.709715Z"
+     "end_time": "2021-09-21T15:58:53.050394Z",
+     "start_time": "2021-09-21T15:58:40.410006Z"
     }
    },
    "outputs": [],
@@ -412,8 +412,8 @@
    "id": "17854931",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2021-09-09T21:49:25.710739Z",
-     "start_time": "2021-09-09T21:49:25.710726Z"
+     "end_time": "2021-09-21T15:59:04.542766Z",
+     "start_time": "2021-09-21T15:58:53.051779Z"
     }
    },
    "outputs": [],
@@ -432,8 +432,8 @@
    "id": "27a3a550",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2021-09-09T21:49:25.711946Z",
-     "start_time": "2021-09-09T21:49:25.711934Z"
+     "end_time": "2021-09-21T15:59:16.413697Z",
+     "start_time": "2021-09-21T15:59:04.544681Z"
     }
    },
    "outputs": [],
@@ -452,8 +452,8 @@
    "id": "628273de",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2021-09-09T21:49:25.713951Z",
-     "start_time": "2021-09-09T21:49:25.713939Z"
+     "end_time": "2021-09-21T15:59:16.444318Z",
+     "start_time": "2021-09-21T15:59:16.415038Z"
     }
    },
    "outputs": [],
@@ -472,8 +472,8 @@
    "id": "00e9e05f",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2021-09-09T21:49:25.714786Z",
-     "start_time": "2021-09-09T21:49:25.714774Z"
+     "end_time": "2021-09-21T15:59:16.473698Z",
+     "start_time": "2021-09-21T15:59:16.445682Z"
     }
    },
    "outputs": [],

--- a/core/dataflow_model/notebooks/Master_model_analyzer.py
+++ b/core/dataflow_model/notebooks/Master_model_analyzer.py
@@ -55,7 +55,8 @@ eval_config = cconfig.Config.from_env_var("AM_CONFIG_CODE")
 # Override config.
 if eval_config is None:
     # experiment_dir = "s3://eglp-spm-sasm/experiments/experiment.RH2Ef.v1_9-all.5T.20210831-004747.run1.tgz"
-    experiment_dir = "/app/oos_experiment.RH2Eg.v2_0-top100.5T.run1_test"
+    #experiment_dir = "/cache/experiments/oos_experiment.RH1E.v2_0-top100.5T"
+    experiment_dir = "/cache/experiments/experiment.RH4E.v2_0-top10.5T"
     aws_profile = None
     selected_idxs = None
 

--- a/helpers/timer.py
+++ b/helpers/timer.py
@@ -186,7 +186,8 @@ class TimedScope:
 
     def __exit__(self, *args: Any) -> None:
         if self._idx is not None:
-            self.elapsed_time = dtimer_stop(self._idx)
+            msg, self.elapsed_time = dtimer_stop(self._idx)
+            _ = msg
 
 
 # #############################################################################

--- a/helpers/timer.py
+++ b/helpers/timer.py
@@ -137,6 +137,9 @@ def dtimer_stop(idx: int) -> Tuple[str, int]:
       - time in seconds (int)
     """
     dbg.dassert_lte(0, idx)
+    # TODO(gp): This assertion might create problems when an exception is
+    # thrown and we don't use context managers to handle the timers. Consider
+    # alternative solutions.
     dbg.dassert_lt(idx, len(_DTIMER_INFO))
     log_level, message, timer = _DTIMER_INFO[idx]
     timer.stop()


### PR DESCRIPTION
- Remove the `payload` if it's still in a ResultBundle
- Converted some old timers in the new context-managed ones that are more robust
- Sprinkle some memory report to monitor the notebook use of memory (mainly for debugging while we improve the memory footprint)