### PR TITLE
Amp task1737 eliminate requirement for index.freq in pipelines 2

### DIFF
--- a/core/dataflow/nodes/sarimax_models.py
+++ b/core/dataflow/nodes/sarimax_models.py
@@ -1,7 +1,6 @@
 import collections
-import datetime
 import logging
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Dict, Optional
 
 import numpy as np
 import pandas as pd
@@ -12,7 +11,6 @@ from tqdm.autonotebook import tqdm
 import core.dataflow.core as cdtfc
 import core.dataflow.nodes.base as cdnb
 import core.dataflow.utils as cdtfu
-import core.signal_processing as csigna
 import helpers.dbg as dbg
 
 _LOG = logging.getLogger(__name__)

--- a/core/dataflow/utils.py
+++ b/core/dataflow/utils.py
@@ -115,7 +115,6 @@ def validate_df_indices(df: pd.DataFrame) -> None:
     """
     dbg.dassert_isinstance(df, pd.DataFrame)
     dbg.dassert_no_duplicates(df.columns.tolist())
-    dbg.dassert(df.index.freq)
     # TODO(*): assert if the datetime index has dups.
 
 

--- a/core/finance.py
+++ b/core/finance.py
@@ -853,6 +853,7 @@ def compute_volatility_normalization_factor(
     :return: scale factor
     """
     dbg.dassert_isinstance(srs, pd.Series)
+    # TODO(Paul): Determine how to deal with no `freq`.
     ppy = hdataf.infer_sampling_points_per_year(srs)
     srs = hdataf.apply_nan_mode(srs, mode="fill_with_zero")
     scale_factor: float = target_volatility / (np.sqrt(ppy) * srs.std())
@@ -960,7 +961,6 @@ def compute_turnover(
     :return: turnover
     """
     dbg.dassert_isinstance(pos, pd.Series)
-    dbg.dassert(pos.index.freq)
     nan_mode = nan_mode or "drop"
     pos = hdataf.apply_nan_mode(pos, mode=nan_mode)
     numerator = pos.diff().abs()
@@ -988,6 +988,7 @@ def compute_average_holding_period(
     """
     unit = unit or "B"
     dbg.dassert_isinstance(pos, pd.Series)
+    # TODO(Paul): Determine how to deal with no `freq`.
     dbg.dassert(pos.index.freq)
     pos_freq_in_year = hdataf.infer_sampling_points_per_year(pos)
     unit_freq_in_year = hdataf.infer_sampling_points_per_year(

--- a/core/finance.py
+++ b/core/finance.py
@@ -634,7 +634,7 @@ def compute_spread_cost(
     dbg.dassert_isinstance(df, pd.DataFrame)
     dbg.dassert_in(target_position_col, df.columns)
     dbg.dassert_in(spread_col, df.columns)
-    #if spread_fraction_paid < 0:
+    # if spread_fraction_paid < 0:
     #    _LOG.warning("spread_fraction_paid=%f", spread_fraction_paid)
     # dbg.dassert_lte(0, spread_fraction_paid)
     dbg.dassert_lte(spread_fraction_paid, 1)

--- a/core/statistics.py
+++ b/core/statistics.py
@@ -1724,7 +1724,9 @@ def compute_bet_stats(
     stats["num_bets"] = bet_lengths.size
     stats["long_bets_(%)"] = 100 * (bet_lengths > 0).sum() / bet_lengths.size
     if positions.index.freq is not None:
-        n_years = positions.size / hdataf.infer_sampling_points_per_year(positions)
+        n_years = positions.size / hdataf.infer_sampling_points_per_year(
+            positions
+        )
         stats["avg_num_bets_per_year"] = bet_lengths.size / n_years
     # Format index.freq outcome to the word that represents its frequency.
     #    E.g. if `srs.index.freq` is equal to `<MonthEnd>` then

--- a/core/statistics.py
+++ b/core/statistics.py
@@ -1243,6 +1243,7 @@ def compute_annualized_sharpe_ratio(
     :param log_rets: time series of log returns
     :return: annualized Sharpe ratio
     """
+    log_rets = cfinan.maybe_resample(log_rets)
     points_per_year = hdataf.infer_sampling_points_per_year(log_rets)
     if isinstance(log_rets, pd.Series):
         log_rets = hdataf.apply_nan_mode(log_rets, mode="fill_with_zero")
@@ -1265,6 +1266,7 @@ def compute_annualized_sharpe_ratio_standard_error(
     :param log_rets: time series of log returns
     :return: standard error estimate of annualized Sharpe ratio
     """
+    log_rets = cfinan.maybe_resample(log_rets)
     points_per_year = hdataf.infer_sampling_points_per_year(log_rets)
     log_rets = hdataf.apply_nan_mode(log_rets, mode="fill_with_zero")
     se_sr = compute_sharpe_ratio_standard_error(log_rets, points_per_year)
@@ -1721,8 +1723,9 @@ def compute_bet_stats(
     stats["num_positions"] = int(bet_lengths.abs().sum())
     stats["num_bets"] = bet_lengths.size
     stats["long_bets_(%)"] = 100 * (bet_lengths > 0).sum() / bet_lengths.size
-    n_years = positions.size / hdataf.infer_sampling_points_per_year(positions)
-    stats["avg_num_bets_per_year"] = bet_lengths.size / n_years
+    if positions.index.freq is not None:
+        n_years = positions.size / hdataf.infer_sampling_points_per_year(positions)
+        stats["avg_num_bets_per_year"] = bet_lengths.size / n_years
     # Format index.freq outcome to the word that represents its frequency.
     #    E.g. if `srs.index.freq` is equal to `<MonthEnd>` then
     #    this line will convert it to the string "Month".


### PR DESCRIPTION
- Remove assertion preventing running dataflow nodes without `index.freq`
- Relax `index.freq` requirements in more places in library functions